### PR TITLE
Support various format in spannerplanviz

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,6 @@ require (
 	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.4
-	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/xlab/treeprint v1.0.1-0.20200814150831-d235141453da
 	golang.org/x/image v0.0.0-20200927104501-e162460cd6b5 // indirect

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/google/go-cmp v0.5.2 // indirect
 	github.com/kr/pretty v0.1.0 // indirect
 	github.com/olekukonko/tablewriter v0.0.4
+	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.4.0 // indirect
 	github.com/xlab/treeprint v1.0.1-0.20200814150831-d235141453da
 	golang.org/x/image v0.0.0-20200927104501-e162460cd6b5 // indirect

--- a/queryplan/extract.go
+++ b/queryplan/extract.go
@@ -1,0 +1,40 @@
+package queryplan
+
+import (
+	"errors"
+
+	"github.com/apstndb/spannerplanviz/protoyaml"
+	"google.golang.org/genproto/googleapis/spanner/v1"
+	"gopkg.in/yaml.v3"
+)
+func ExtractQueryPlan(b []byte) (*spanner.ResultSetStats, *spanner.StructType, error) {
+	var jsonObj map[string]interface{}
+	err := yaml.Unmarshal(b, &jsonObj)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if _, ok := jsonObj["queryPlan"]; ok {
+		var rss spanner.ResultSetStats
+		err = protoyaml.Unmarshal(b, &rss)
+		if err != nil {
+			return nil,nil,  err
+		}
+		return &rss, nil, nil
+	} else if _, ok := jsonObj["planNodes"]; ok {
+		var qp spanner.QueryPlan
+		err = protoyaml.Unmarshal(b, &qp)
+		if err != nil {
+			return nil, nil,  err
+		}
+		return &spanner.ResultSetStats{QueryPlan: &qp}, nil, nil
+	} else if _, ok := jsonObj["stats"]; ok {
+		var rs spanner.ResultSet
+		err = protoyaml.Unmarshal(b, &rs)
+		if err != nil {
+			return nil, nil,  err
+		}
+		return rs.GetStats(), rs.GetMetadata().GetRowType(), nil
+	}
+	return nil, nil, errors.New("unknown input format")
+}

--- a/queryplan/extract.go
+++ b/queryplan/extract.go
@@ -7,6 +7,7 @@ import (
 	"google.golang.org/genproto/googleapis/spanner/v1"
 	"gopkg.in/yaml.v3"
 )
+
 func ExtractQueryPlan(b []byte) (*spanner.ResultSetStats, *spanner.StructType, error) {
 	var jsonObj map[string]interface{}
 	err := yaml.Unmarshal(b, &jsonObj)
@@ -18,21 +19,21 @@ func ExtractQueryPlan(b []byte) (*spanner.ResultSetStats, *spanner.StructType, e
 		var rss spanner.ResultSetStats
 		err = protoyaml.Unmarshal(b, &rss)
 		if err != nil {
-			return nil,nil,  err
+			return nil, nil, err
 		}
 		return &rss, nil, nil
 	} else if _, ok := jsonObj["planNodes"]; ok {
 		var qp spanner.QueryPlan
 		err = protoyaml.Unmarshal(b, &qp)
 		if err != nil {
-			return nil, nil,  err
+			return nil, nil, err
 		}
 		return &spanner.ResultSetStats{QueryPlan: &qp}, nil, nil
 	} else if _, ok := jsonObj["stats"]; ok {
 		var rs spanner.ResultSet
 		err = protoyaml.Unmarshal(b, &rs)
 		if err != nil {
-			return nil, nil,  err
+			return nil, nil, err
 		}
 		return rs.GetStats(), rs.GetMetadata().GetRowType(), nil
 	}


### PR DESCRIPTION
Same as #3 in spannerplanviz.

This commit decommission the undocumented support of `[]PartialResultSet` because old spanner console is not available anymore.