### PR TITLE
fix: Allow unkown stats

### DIFF
--- a/cmd/rendertree/main.go
+++ b/cmd/rendertree/main.go
@@ -271,7 +271,7 @@ func run() error {
 
 	var opts []plantree.Option
 	if *disallowUnknownStats {
-		opts = append(opts, plantree.DisallowUnknownField())
+		opts = append(opts, plantree.DisallowUnknownStats())
 	}
 
 	rows, err := plantree.ProcessPlan(queryplan.New(stats.GetQueryPlan().GetPlanNodes()), opts...)

--- a/cmd/rendertree/main.go
+++ b/cmd/rendertree/main.go
@@ -12,11 +12,12 @@ import (
 	"text/template"
 
 	"github.com/apstndb/lox"
-	"github.com/apstndb/spannerplanviz/plantree"
-	"github.com/apstndb/spannerplanviz/queryplan"
 	"github.com/olekukonko/tablewriter"
 	"github.com/samber/lo"
 	"gopkg.in/yaml.v3"
+
+	"github.com/apstndb/spannerplanviz/plantree"
+	"github.com/apstndb/spannerplanviz/queryplan"
 )
 
 func main() {
@@ -235,6 +236,8 @@ func run() error {
 	customFile := flag.String("custom-file", "", "")
 	mode := flag.String("mode", "", "PROFILE or PLAN(ignore case)")
 	printModeStr := flag.String("print", "predicates", "print node parameters(EXPERIMENTAL)")
+	disallowUnknownStats := flag.Bool("disallow-unknown-stats", false, "error on unknown stats field")
+
 	var custom stringList
 	flag.Var(&custom, "custom", "")
 	flag.Parse()
@@ -266,7 +269,12 @@ func run() error {
 		return fmt.Errorf("invalid input at protoyaml.Unmarshal:\nerror: %w\ninput: %.*s%s", err, jsonSnippetLen, strings.TrimSpace(string(b)), collapsedStr)
 	}
 
-	rows, err := plantree.ProcessPlan(queryplan.New(stats.GetQueryPlan().GetPlanNodes()))
+	var opts []plantree.Option
+	if *disallowUnknownStats {
+		opts = append(opts, plantree.DisallowUnknownField())
+	}
+
+	rows, err := plantree.ProcessPlan(queryplan.New(stats.GetQueryPlan().GetPlanNodes()), opts...)
 	if err != nil {
 		return err
 	}

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -43,18 +43,18 @@ func (r RowWithPredicates) FormatID() string {
 	return lox.IfOrEmpty(len(r.Predicates) != 0, "*") + strconv.Itoa(int(r.ID))
 }
 
-type options struct{ disallowUnknownField bool }
+type options struct{ disallowUnknownStats bool }
 type Option func(*options) error
 
-func DisallowUnknownField() Option {
+func DisallowUnknownStats() Option {
 	return func(o *options) error {
-		o.disallowUnknownField = true
+		o.disallowUnknownStats = true
 		return nil
 	}
 }
-func AllowUnknownField() Option {
+func AllowUnknownStats() Option {
 	return func(o *options) error {
-		o.disallowUnknownField = false
+		o.disallowUnknownStats = false
 		return nil
 	}
 }
@@ -114,7 +114,7 @@ func ProcessPlan(qp *queryplan.QueryPlan, opts ...Option) (rows []RowWithPredica
 		})
 
 		var executionStats stats.ExecutionStats
-		if err := jsonRoundtrip(node.GetExecutionStats(), &executionStats, o.disallowUnknownField); err != nil {
+		if err := jsonRoundtrip(node.GetExecutionStats(), &executionStats, o.disallowUnknownStats); err != nil {
 			return nil, err
 		}
 

--- a/stats/types.go
+++ b/stats/types.go
@@ -37,17 +37,18 @@ type ExecutionStatsSummary struct {
 }
 
 type ExecutionStats struct {
-	DiskUsageKBytes        ExecutionStatsValue   `json:"Disk Usage (KBytes)"`
-	DiskWriteLatencyMsecs  ExecutionStatsValue   `json:"Disk Write Latency (msecs)"`
-	PeakMemoryUsageKBytes  ExecutionStatsValue   `json:"Peak Memory Usage (KBytes)"`
-	RowsSpooled            ExecutionStatsValue   `json:"Rows Spooled"`
-	Rows                   ExecutionStatsValue   `json:"rows"`
-	Latency                ExecutionStatsValue   `json:"latency"`
-	CpuTime                ExecutionStatsValue   `json:"cpu_time"`
-	DeletedRows            ExecutionStatsValue   `json:"deleted_rows"`
-	FilesystemDelaySeconds ExecutionStatsValue   `json:"filesystem_delay_seconds"`
-	FilteredRows           ExecutionStatsValue   `json:"filtered_rows"`
-	RemoteCalls            ExecutionStatsValue   `json:"remote_calls"`
-	ScannedRows            ExecutionStatsValue   `json:"scanned_rows"`
-	ExecutionSummary       ExecutionStatsSummary `json:"execution_summary"`
+	DiskUsageKBytes                ExecutionStatsValue   `json:"Disk Usage (KBytes)"`
+	DiskWriteLatencyMsecs          ExecutionStatsValue   `json:"Disk Write Latency (msecs)"`
+	PeekBufferingMemoryUsageKBytes ExecutionStatsValue   `json:"Peak Buffering Memory Usage (KBytes)"`
+	PeakMemoryUsageKBytes          ExecutionStatsValue   `json:"Peak Memory Usage (KBytes)"`
+	RowsSpooled                    ExecutionStatsValue   `json:"Rows Spooled"`
+	Rows                           ExecutionStatsValue   `json:"rows"`
+	Latency                        ExecutionStatsValue   `json:"latency"`
+	CpuTime                        ExecutionStatsValue   `json:"cpu_time"`
+	DeletedRows                    ExecutionStatsValue   `json:"deleted_rows"`
+	FilesystemDelaySeconds         ExecutionStatsValue   `json:"filesystem_delay_seconds"`
+	FilteredRows                   ExecutionStatsValue   `json:"filtered_rows"`
+	RemoteCalls                    ExecutionStatsValue   `json:"remote_calls"`
+	ScannedRows                    ExecutionStatsValue   `json:"scanned_rows"`
+	ExecutionSummary               ExecutionStatsSummary `json:"execution_summary"`
 }


### PR DESCRIPTION
This PR fixes rendertree error on unknown stats.

- Use `--disallow-unknown-stats` (`DisallowUnknownStats`) option for old behavior.
- Add `PeekBufferingMemoryUsageKBytes`