### PR TITLE
Implement TargetMetadataFormat

### DIFF
--- a/cmd/rendertree/main.go
+++ b/cmd/rendertree/main.go
@@ -237,8 +237,8 @@ func run() error {
 	mode := flag.String("mode", "", "PROFILE or PLAN(ignore case)")
 	printModeStr := flag.String("print", "predicates", "print node parameters(EXPERIMENTAL)")
 	disallowUnknownStats := flag.Bool("disallow-unknown-stats", false, "error on unknown stats field")
-	executionMethod := flag.String("execution-method", "angle", "raw or angle(default)")
-	targetMetadata := flag.String("target-metadata", "on", "raw or on(default)")
+	executionMethod := flag.String("execution-method", "angle", "Format execution method metadata: 'angle' or 'raw' (default: angle)")
+	targetMetadata := flag.String("target-metadata", "on", "Format target metadata: 'on' or 'raw' (default: on)")
 
 	var custom stringList
 	flag.Var(&custom, "custom", "")
@@ -268,6 +268,7 @@ func run() error {
 	case "RAW":
 		opts = append(opts, plantree.WithQueryPlanOptions(queryplan.WithExecutionMethodFormat(queryplan.ExecutionMethodFormatRaw)))
 	default:
+		fmt.Fprintf(os.Stderr, "\nInvalid value for -execution-method flag: %s.  Must be 'angle' or 'raw'.\n", *targetMetadata)
 		flag.Usage()
 		os.Exit(1)
 	}
@@ -278,6 +279,7 @@ func run() error {
 	case "RAW":
 		opts = append(opts, plantree.WithQueryPlanOptions(queryplan.WithTargetMetadataFormat(queryplan.TargetMetadataFormatRaw)))
 	default:
+		fmt.Fprintf(os.Stderr, "\nInvalid value for -target-metadata flag: %s.  Must be 'on' or 'raw'.\n", *targetMetadata)
 		flag.Usage()
 		os.Exit(1)
 	}

--- a/cmd/rendertree/main.go
+++ b/cmd/rendertree/main.go
@@ -238,6 +238,7 @@ func run() error {
 	printModeStr := flag.String("print", "predicates", "print node parameters(EXPERIMENTAL)")
 	disallowUnknownStats := flag.Bool("disallow-unknown-stats", false, "error on unknown stats field")
 	executionMethod := flag.String("execution-method", "angle", "raw or angle(default)")
+	targetMetadata := flag.String("target-metadata", "on", "raw or on(default)")
 
 	var custom stringList
 	flag.Var(&custom, "custom", "")
@@ -266,6 +267,16 @@ func run() error {
 		opts = append(opts, plantree.WithQueryPlanOptions(queryplan.WithExecutionMethodFormat(queryplan.ExecutionMethodFormatAngle)))
 	case "RAW":
 		opts = append(opts, plantree.WithQueryPlanOptions(queryplan.WithExecutionMethodFormat(queryplan.ExecutionMethodFormatRaw)))
+	default:
+		flag.Usage()
+		os.Exit(1)
+	}
+
+	switch strings.ToUpper(*targetMetadata) {
+	case "", "ON":
+		opts = append(opts, plantree.WithQueryPlanOptions(queryplan.WithTargetMetadataFormat(queryplan.TargetMetadataFormatOn)))
+	case "RAW":
+		opts = append(opts, plantree.WithQueryPlanOptions(queryplan.WithTargetMetadataFormat(queryplan.TargetMetadataFormatRaw)))
 	default:
 		flag.Usage()
 		os.Exit(1)


### PR DESCRIPTION
This PR introduces `TargetMetadataFormat`(`--target-metadata`) and make new format as the default in rendertree.
I believe it highlights the target of operation, and reduces column width.

## Example

```sql
SELECT *
FROM Singers
JOIN Albums USING(SingerId)
WHERE LastName LIKE 'A%'
```

### `TargetMetadataFormatRaw` (Original)
```
+-----+----------------------------------------------------------------------------------------------------------+
| ID  | Operator                                                                                                 |
+-----+----------------------------------------------------------------------------------------------------------+
|  *0 | Distributed Union <Row> (distribution_table: SingersByLastNameDescCovering, split_ranges_aligned: false) |
|  *1 | +- Distributed Cross Apply <Row>                                                                         |
|   2 |    +- Create Batch <Row>                                                                                 |
|   3 |    |  +- Local Distributed Union <Row>                                                                   |
|   4 |    |     +- Compute Struct <Row>                                                                         |
|   5 |    |        +- Filter Scan <Row> (seekable_key_size: 1)                                                  |
|  *6 |    |           +- Index Scan <Row> (Index: SingersByLastNameDescCovering, scan_method: Row)              |
|  22 |    +- [Map] Serialize Result <Row>                                                                       |
|  23 |       +- Cross Apply <Row>                                                                               |
|  24 |          +- KeyRangeAccumulator <Row>                                                                    |
|  25 |          |  +- Batch Scan <Row> (Batch: $v2, scan_method: Row)                                           |
|  31 |          +- [Map] Local Distributed Union <Row>                                                          |
|  32 |             +- Filter Scan <Row> (seekable_key_size: 0)                                                  |
| *33 |                +- Table Scan <Row> (Table: Albums, scan_method: Row)                                     |
+-----+----------------------------------------------------------------------------------------------------------+
```
### `TargetMetadataFormatOn` (New Default)

`distribution_table` and `scan_target` metadata is printed as `on <target>` after operator name.

```
+-----+----------------------------------------------------------------------------------------+
| ID  | Operator                                                                               |
+-----+----------------------------------------------------------------------------------------+
|  *0 | Distributed Union on SingersByLastNameDescCovering <Row> (split_ranges_aligned: false) |
|  *1 | +- Distributed Cross Apply <Row>                                                       |
|   2 |    +- Create Batch <Row>                                                               |
|   3 |    |  +- Local Distributed Union <Row>                                                 |
|   4 |    |     +- Compute Struct <Row>                                                       |
|   5 |    |        +- Filter Scan <Row> (seekable_key_size: 1)                                |
|  *6 |    |           +- Index Scan on SingersByLastNameDescCovering <Row> (scan_method: Row) |
|  22 |    +- [Map] Serialize Result <Row>                                                     |
|  23 |       +- Cross Apply <Row>                                                             |
|  24 |          +- KeyRangeAccumulator <Row>                                                  |
|  25 |          |  +- Batch Scan on $v2 <Row> (scan_method: Row)                              |
|  31 |          +- [Map] Local Distributed Union <Row>                                        |
|  32 |             +- Filter Scan <Row> (seekable_key_size: 0)                                |
| *33 |                +- Table Scan on Albums <Row> (scan_method: Row)                        |
+-----+----------------------------------------------------------------------------------------+
```


## Related Issue 

- https://github.com/apstndb/spanner-mycli/issues/182