### PR TITLE
Fix to add newline to node parameters and predicates line

### DIFF
--- a/cmd/rendertree/main.go
+++ b/cmd/rendertree/main.go
@@ -459,16 +459,16 @@ func printResult(renderDef tableRenderDef, rows []plantree.RowWithPredicates, pr
 	switch printMode {
 	case PrintFull, PrintTyped:
 		if len(parameters) > 0 {
-			b.WriteString("Node Parameters(identified by ID):")
+			fmt.Fprintln(&b, "Node Parameters(identified by ID):")
 			for _, s := range parameters {
-				b.WriteString(fmt.Sprintf(" %s\n", s))
+				fmt.Fprintf(&b, " %s\n", s)
 			}
 		}
 	case PrintPredicates:
 		if len(predicates) > 0 {
-			b.WriteString("Predicates(identified by ID):")
+			fmt.Fprintln(&b, "Predicates(identified by ID):")
 			for _, s := range predicates {
-				b.WriteString(fmt.Sprintf(" %s\n", s))
+				fmt.Fprintf(&b, " %s\n", s)
 			}
 		}
 	}


### PR DESCRIPTION
This PR fixes the bug of the first line of predicates don't be prefixed by newline in rendertree.

before

```
+----+-----------------------------------------------------------------------------------+
| ID | Operator                                                                          |
+----+-----------------------------------------------------------------------------------+
|  0 | Distributed Union on Singers <Row> (split_ranges_aligned: false)                  |
|  1 | +- Local Distributed Union <Row>                                                  |
|  2 |    +- Serialize Result <Row>                                                      |
| *3 |       +- Filter Scan <Row> (seekable_key_size: 0)                                 |
|  4 |          +- Table Scan on Singers <Row> (Full scan: true, scan_method: Automatic) |
+----+-----------------------------------------------------------------------------------+
Predicates(identified by ID): 3: Residual Condition: ($LastName LIKE '%A')
```

after

```
+----+-----------------------------------------------------------------------------------+
| ID | Operator                                                                          |
+----+-----------------------------------------------------------------------------------+
|  0 | Distributed Union on Singers <Row> (split_ranges_aligned: false)                  |
|  1 | +- Local Distributed Union <Row>                                                  |
|  2 |    +- Serialize Result <Row>                                                      |
| *3 |       +- Filter Scan <Row> (seekable_key_size: 0)                                 |
|  4 |          +- Table Scan on Singers <Row> (Full scan: true, scan_method: Automatic) |
+----+-----------------------------------------------------------------------------------+
Predicates(identified by ID):
 3: Residual Condition: ($LastName LIKE '%A')
```