### PR TITLE
Fix to treat the first child of Apply as Input type

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -3,13 +3,12 @@ on:
   push:
     branches:
       - main
-      - master
   pull_request:
 
 permissions:
   contents: read
   # Optional: allow read access to pull request. Use with `only-new-issues` option.
-  # pull-requests: read
+  pull-requests: read
 
 jobs:
   golangci:

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -15,7 +15,6 @@
 on:
   push:
     branches:
-      - master
       - main
   pull_request:
 name: CI

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -1,0 +1,32 @@
+# Copyright 2022 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+on:
+  push:
+    branches:
+      - master
+      - main
+  pull_request:
+name: CI
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+      - run: go version
+      - name: make test-verbose
+        run: make test-verbose

--- a/.github/workflows/run-tests.yaml
+++ b/.github/workflows/run-tests.yaml
@@ -27,5 +27,4 @@ jobs:
         with:
           go-version: '1.24'
       - run: go version
-      - name: make test-verbose
-        run: make test-verbose
+      - run: go test -v ./...

--- a/cmd/rendertree/main_test.go
+++ b/cmd/rendertree/main_test.go
@@ -1,9 +1,15 @@
 package main
 
 import (
+	_ "embed"
+	"strings"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
 	"github.com/olekukonko/tablewriter"
+
+	"github.com/apstndb/spannerplanviz/plantree"
+	"github.com/apstndb/spannerplanviz/queryplan"
 )
 
 func Test_customFileToTableRenderDef(t *testing.T) {
@@ -23,5 +29,59 @@ func Test_customFileToTableRenderDef(t *testing.T) {
 	}
 	if v := trd.Columns[0]; v.Alignment != tablewriter.ALIGN_RIGHT {
 		t.Fatalf("unexpected value: %v", v)
+	}
+}
+
+//go:embed testdata/distributed_cross_apply.yaml
+var dcaYAML []byte
+
+func TestRenderTree(t *testing.T) {
+	stats, _, err := queryplan.ExtractQueryPlan([]byte(dcaYAML))
+	if err != nil {
+		var collapsedStr string
+		if len(dcaYAML) > jsonSnippetLen {
+			collapsedStr = "(collapsed)"
+		}
+		t.Fatalf("invalid input at protoyaml.Unmarshal:\nerror: %v\ninput: %.*s%s", err, jsonSnippetLen, strings.TrimSpace(string(dcaYAML)), collapsedStr)
+	}
+
+	rows, err := plantree.ProcessPlan(queryplan.New(stats.GetQueryPlan().GetPlanNodes()), plantree.WithQueryPlanOptions(
+		queryplan.WithTargetMetadataFormat(queryplan.TargetMetadataFormatOn),
+		queryplan.WithExecutionMethodFormat(queryplan.ExecutionMethodFormatAngle),
+		queryplan.WithFullScanFormat(queryplan.FullScanFormatLabel),
+	))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	renderDef := withStatsToRenderDefMap[false]
+
+	want := `+-----+-------------------------------------------------------------------------------------------+
+| ID  | Operator                                                                                  |
++-----+-------------------------------------------------------------------------------------------+
+|   0 | Distributed Union on AlbumsByAlbumTitle <Row> (split_ranges_aligned: false)               |
+|  *1 | +- Distributed Cross Apply <Row>                                                          |
+|   2 |    +- [Input] Create Batch <Row>                                                          |
+|   3 |    |  +- Local Distributed Union <Row>                                                    |
+|   4 |    |     +- Compute Struct <Row>                                                          |
+|   5 |    |        +- Index Scan on AlbumsByAlbumTitle <Row> (Full scan, scan_method: Automatic) |
+|  11 |    +- [Map] Serialize Result <Row>                                                        |
+|  12 |       +- Cross Apply <Row>                                                                |
+|  13 |          +- [Input] Batch Scan on $v2 <Row> (scan_method: Row)                            |
+|  16 |          +- [Map] Local Distributed Union <Row>                                           |
+| *17 |             +- Filter Scan <Row> (seekable_key_size: 0)                                   |
+|  18 |                +- Index Scan on SongsBySongGenre <Row> (Full scan, scan_method: Row)      |
++-----+-------------------------------------------------------------------------------------------+
+Predicates(identified by ID):
+  1: Split Range: ($AlbumId = $AlbumId_1)
+ 17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
+`
+	s, err := printResult(renderDef, rows, PrintPredicates)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if diff := cmp.Diff(want, s); diff != "" {
+		t.Errorf("mismatch (-want +got):\n%s", diff)
 	}
 }

--- a/cmd/rendertree/testdata/distributed_cross_apply.yaml
+++ b/cmd/rendertree/testdata/distributed_cross_apply.yaml
@@ -1,0 +1,232 @@
+metadata:
+    rowType:
+        fields:
+            - name: albumtitle
+              type:
+                code: STRING
+    transaction:
+        readTimestamp: "2025-04-20T03:15:18.412872Z"
+    undeclaredParameters: {}
+stats:
+    queryPlan:
+        planNodes:
+            - childLinks:
+                - childIndex: 1
+                - childIndex: 28
+                  type: Split Range
+              displayName: Distributed Union
+              kind: RELATIONAL
+              metadata:
+                distribution_table: AlbumsByAlbumTitle
+                execution_method: Row
+                split_ranges_aligned: "false"
+                subquery_cluster_node: "1"
+            - childLinks:
+                - childIndex: 2
+                - childIndex: 11
+                  type: Map
+                - childIndex: 25
+                  type: Split Range
+              displayName: Distributed Cross Apply
+              index: 1
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+                subquery_cluster_node: "11"
+            - childLinks:
+                - childIndex: 3
+                - childIndex: 10
+                  variable: v2.Batch
+              displayName: Create Batch
+              index: 2
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+            - childLinks:
+                - childIndex: 4
+              displayName: Distributed Union
+              index: 3
+              kind: RELATIONAL
+              metadata:
+                call_type: Local
+                execution_method: Row
+                subquery_cluster_node: "4"
+            - childLinks:
+                - childIndex: 5
+                - childIndex: 8
+                  variable: v1.AlbumId_1
+                - childIndex: 9
+                  variable: v1.AlbumTitle
+              displayName: Compute Struct
+              index: 4
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+            - childLinks:
+                - childIndex: 6
+                  variable: AlbumId_1
+                - childIndex: 7
+                  variable: AlbumTitle
+              displayName: Scan
+              index: 5
+              kind: RELATIONAL
+              metadata:
+                Full scan: "true"
+                execution_method: Row
+                scan_method: Automatic
+                scan_target: AlbumsByAlbumTitle
+                scan_type: IndexScan
+            - displayName: Reference
+              index: 6
+              kind: SCALAR
+              shortRepresentation:
+                description: AlbumId
+            - displayName: Reference
+              index: 7
+              kind: SCALAR
+              shortRepresentation:
+                description: AlbumTitle
+            - displayName: Reference
+              index: 8
+              kind: SCALAR
+              shortRepresentation:
+                description: $AlbumId_1
+            - displayName: Reference
+              index: 9
+              kind: SCALAR
+              shortRepresentation:
+                description: $AlbumTitle
+            - displayName: Reference
+              index: 10
+              kind: SCALAR
+              shortRepresentation:
+                description: $v1
+            - childLinks:
+                - childIndex: 12
+                - childIndex: 24
+              displayName: Serialize Result
+              index: 11
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+            - childLinks:
+                - childIndex: 13
+                - childIndex: 16
+                  type: Map
+              displayName: Cross Apply
+              index: 12
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+            - childLinks:
+                - childIndex: 14
+                  variable: batched_AlbumId_1
+                - childIndex: 15
+                  variable: batched_AlbumTitle
+              displayName: Scan
+              index: 13
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+                scan_method: Row
+                scan_target: $v2
+                scan_type: BatchScan
+            - displayName: Reference
+              index: 14
+              kind: SCALAR
+              shortRepresentation:
+                description: AlbumId_1
+            - displayName: Reference
+              index: 15
+              kind: SCALAR
+              shortRepresentation:
+                description: AlbumTitle
+            - childLinks:
+                - childIndex: 17
+              displayName: Distributed Union
+              index: 16
+              kind: RELATIONAL
+              metadata:
+                call_type: Local
+                execution_method: Row
+                subquery_cluster_node: "17"
+            - childLinks:
+                - childIndex: 18
+                - childIndex: 23
+                  type: Residual Condition
+              displayName: Filter Scan
+              index: 17
+              kind: RELATIONAL
+              metadata:
+                execution_method: Row
+                seekable_key_size: "0"
+            - childLinks:
+                - childIndex: 19
+                  variable: AlbumId
+              displayName: Scan
+              index: 18
+              kind: RELATIONAL
+              metadata:
+                Full scan: "true"
+                execution_method: Row
+                scan_method: Row
+                scan_target: SongsBySongGenre
+                scan_type: IndexScan
+            - displayName: Reference
+              index: 19
+              kind: SCALAR
+              shortRepresentation:
+                description: AlbumId
+            - childLinks:
+                - childIndex: 21
+                - childIndex: 22
+              displayName: Function
+              index: 20
+              kind: SCALAR
+              shortRepresentation:
+                description: ($AlbumId = $batched_AlbumId_1)
+            - displayName: Reference
+              index: 21
+              kind: SCALAR
+              shortRepresentation:
+                description: $AlbumId
+            - displayName: Reference
+              index: 22
+              kind: SCALAR
+              shortRepresentation:
+                description: $batched_AlbumId_1
+            - childLinks:
+                - childIndex: 20
+              displayName: Function
+              index: 23
+              kind: SCALAR
+              shortRepresentation:
+                description: ($AlbumId = $batched_AlbumId_1)
+            - displayName: Reference
+              index: 24
+              kind: SCALAR
+              shortRepresentation:
+                description: $batched_AlbumTitle
+            - childLinks:
+                - childIndex: 26
+                - childIndex: 27
+              displayName: Function
+              index: 25
+              kind: SCALAR
+              shortRepresentation:
+                description: ($AlbumId = $AlbumId_1)
+            - displayName: Reference
+              index: 26
+              kind: SCALAR
+              shortRepresentation:
+                description: $AlbumId
+            - displayName: Reference
+              index: 27
+              kind: SCALAR
+              shortRepresentation:
+                description: $AlbumId_1
+            - displayName: Constant
+              index: 28
+              kind: SCALAR
+              shortRepresentation:
+                description: "true"

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	cloud.google.com/go/spanner v1.48.0
 	github.com/apstndb/lox v0.0.0-20230530141045-98c1efebcde8
 	github.com/goccy/go-graphviz v0.2.2
+	github.com/google/go-cmp v0.5.9
 	github.com/jessevdk/go-flags v1.6.1
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/samber/lo v1.47.0

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -86,11 +86,17 @@ func ProcessPlan(qp *queryplan.QueryPlan, opts ...Option) (rows []RowWithPredica
 		}
 
 		node := qp.GetNodeByIndex(link.GetChildIndex())
+		parent := qp.GetParentNodeByChildLink(&link)
+
 		displayName := queryplan.NodeTitle(node, o.queryplanOptions...)
 
 		var text string
 		if link.GetType() != "" {
 			text = fmt.Sprintf("[%s] %s", link.GetType(), displayName)
+
+			// Workaround to treat the first child of Cross Apply as Input
+		} else if parent != nil && strings.HasSuffix(parent.GetDisplayName(), "Apply") && parent.GetChildLinks()[0].GetChildIndex() == link.GetChildIndex() {
+			text = fmt.Sprintf("[%s] %s", "Input", displayName)
 		} else {
 			text = displayName
 		}

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -94,7 +94,9 @@ func ProcessPlan(qp *queryplan.QueryPlan, opts ...Option) (rows []RowWithPredica
 		if link.GetType() != "" {
 			text = fmt.Sprintf("[%s] %s", link.GetType(), displayName)
 
-			// Workaround to treat the first child of Cross Apply as Input
+			// Workaround to treat the first child of Apply as Input.
+			// This is necessary because it is more consistent with the official query plan operator docs.
+			// Note: Apply variants are Cross Apply, Anti Semi Apply, Semi Apply, Outer Apply, and their Distributed variants.
 		} else if parent != nil && strings.HasSuffix(parent.GetDisplayName(), "Apply") && parent.GetChildLinks()[0].GetChildIndex() == link.GetChildIndex() {
 			text = fmt.Sprintf("[%s] %s", "Input", displayName)
 		} else {


### PR DESCRIPTION
This PR fixes to treat the first child of `* Apply` as `Input type`.
It is important to align with the official docs.

before

```
+-----+-------------------------------------------------------------------------------------------+
| ID  | Operator                                                                                  |
+-----+-------------------------------------------------------------------------------------------+
|   0 | Distributed Union on AlbumsByAlbumTitle <Row> (split_ranges_aligned: false)               |
|  *1 | +- Distributed Cross Apply <Row>                                                          |
|   2 |    +- Create Batch <Row>                                                                  |
|   3 |    |  +- Local Distributed Union <Row>                                                    |
|   4 |    |     +- Compute Struct <Row>                                                          |
|   5 |    |        +- Index Scan on AlbumsByAlbumTitle <Row> (Full scan, scan_method: Automatic) |
|  11 |    +- [Map] Serialize Result <Row>                                                        |
|  12 |       +- Cross Apply <Row>                                                                |
|  13 |          +- Batch Scan on $v2 <Row> (scan_method: Row)                                    |
|  16 |          +- [Map] Local Distributed Union <Row>                                           |
| *17 |             +- Filter Scan <Row> (seekable_key_size: 0)                                   |
|  18 |                +- Index Scan on SongsBySongGenre <Row> (Full scan, scan_method: Row)      |
+-----+-------------------------------------------------------------------------------------------+
Predicates(identified by ID):
  1: Split Range: ($AlbumId = $AlbumId_1)
 17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
```

after

```
+-----+-------------------------------------------------------------------------------------------+
| ID  | Operator                                                                                  |
+-----+-------------------------------------------------------------------------------------------+
|   0 | Distributed Union on AlbumsByAlbumTitle <Row> (split_ranges_aligned: false)               |
|  *1 | +- Distributed Cross Apply <Row>                                                          |
|   2 |    +- [Input] Create Batch <Row>                                                          |
|   3 |    |  +- Local Distributed Union <Row>                                                    |
|   4 |    |     +- Compute Struct <Row>                                                          |
|   5 |    |        +- Index Scan on AlbumsByAlbumTitle <Row> (Full scan, scan_method: Automatic) |
|  11 |    +- [Map] Serialize Result <Row>                                                        |
|  12 |       +- Cross Apply <Row>                                                                |
|  13 |          +- [Input] Batch Scan on $v2 <Row> (scan_method: Row)                            |
|  16 |          +- [Map] Local Distributed Union <Row>                                           |
| *17 |             +- Filter Scan <Row> (seekable_key_size: 0)                                   |
|  18 |                +- Index Scan on SongsBySongGenre <Row> (Full scan, scan_method: Row)      |
+-----+-------------------------------------------------------------------------------------------+
Predicates(identified by ID):
  1: Split Range: ($AlbumId = $AlbumId_1)
 17: Residual Condition: ($AlbumId = $batched_AlbumId_1)
```