### PR TITLE
feat: Implement --known-flag

### DIFF
--- a/cmd/rendertree/main.go
+++ b/cmd/rendertree/main.go
@@ -195,8 +195,13 @@ func run() error {
 	disallowUnknownStats := flag.Bool("disallow-unknown-stats", false, "error on unknown stats field")
 	executionMethod := flag.String("execution-method", "angle", "Format execution method metadata: 'angle' or 'raw' (default: angle)")
 	targetMetadata := flag.String("target-metadata", "on", "Format target metadata: 'on' or 'raw' (default: on)")
-	fullscan := flag.String("full-scan", "label", "Format full scan: 'label' or 'raw' (default: label)")
+	fullscan := flag.String("full-scan", "", "Alias of --known-flag")
+	knownFlag := flag.String("known-flag", "label", "Format known flags: 'label' or 'raw' (default: label)")
 	compact := flag.Bool("compact", false, "Enable compact format")
+
+	if *fullscan != "" {
+		*knownFlag = *fullscan
+	}
 
 	var custom stringList
 	flag.Var(&custom, "custom", "")
@@ -246,11 +251,11 @@ func run() error {
 		os.Exit(1)
 	}
 
-	switch strings.ToUpper(*fullscan) {
+	switch strings.ToUpper(*knownFlag) {
 	case "", "LABEL":
-		opts = append(opts, plantree.WithQueryPlanOptions(queryplan.WithFullScanFormat(queryplan.FullScanFormatLabel)))
+		opts = append(opts, plantree.WithQueryPlanOptions(queryplan.WithKnownFlagFormat(queryplan.KnownFlagFormatLabel)))
 	case "RAW":
-		opts = append(opts, plantree.WithQueryPlanOptions(queryplan.WithFullScanFormat(queryplan.FullScanFormatRaw)))
+		opts = append(opts, plantree.WithQueryPlanOptions(queryplan.WithKnownFlagFormat(queryplan.KnownFlagFormatRaw)))
 	default:
 		fmt.Fprintf(os.Stderr, "Invalid value for -full-scan flag: %s.  Must be 'label' or 'raw'.\n", *fullscan)
 		flag.Usage()

--- a/cmd/rendertree/main.go
+++ b/cmd/rendertree/main.go
@@ -262,7 +262,7 @@ func run() error {
 	case "RAW":
 		opts = append(opts, plantree.WithQueryPlanOptions(queryplan.WithKnownFlagFormat(queryplan.KnownFlagFormatRaw)))
 	default:
-		fmt.Fprintf(os.Stderr, "Invalid value for -full-scan flag: %s.  Must be 'label' or 'raw'.\n", *fullscan)
+		fmt.Fprintf(os.Stderr, "Invalid value for -known-flag flag: %s.  Must be 'label' or 'raw'.\n", *knownFlag)
 		flag.Usage()
 		os.Exit(1)
 	}

--- a/cmd/rendertree/main.go
+++ b/cmd/rendertree/main.go
@@ -195,17 +195,22 @@ func run() error {
 	disallowUnknownStats := flag.Bool("disallow-unknown-stats", false, "error on unknown stats field")
 	executionMethod := flag.String("execution-method", "angle", "Format execution method metadata: 'angle' or 'raw' (default: angle)")
 	targetMetadata := flag.String("target-metadata", "on", "Format target metadata: 'on' or 'raw' (default: on)")
-	fullscan := flag.String("full-scan", "", "Alias of --known-flag")
-	knownFlag := flag.String("known-flag", "label", "Format known flags: 'label' or 'raw' (default: label)")
+	fullscan := flag.String("full-scan", "", "Deprecated alias for --known-flag.")
+	knownFlag := flag.String("known-flag", "", "Format known flags: 'label' or 'raw' (default: label)")
 	compact := flag.Bool("compact", false, "Enable compact format")
-
-	if *fullscan != "" {
-		*knownFlag = *fullscan
-	}
 
 	var custom stringList
 	flag.Var(&custom, "custom", "")
 	flag.Parse()
+
+	if *fullscan != "" {
+		if *knownFlag != "" {
+			fmt.Fprintln(os.Stderr, "--full-scan and --known-flag are mutually exclusive.")
+			flag.Usage()
+			os.Exit(1)
+		}
+		*knownFlag = *fullscan
+	}
 
 	printMode := parsePrintMode(*printModeStr)
 

--- a/cmd/rendertree/main.go
+++ b/cmd/rendertree/main.go
@@ -209,6 +209,9 @@ func run() error {
 			flag.Usage()
 			os.Exit(1)
 		}
+
+		fmt.Fprintln(os.Stderr, "--full-scan is deprecated. you must migrate to --known-flag.")
+
 		*knownFlag = *fullscan
 	}
 

--- a/cmd/rendertree/main_test.go
+++ b/cmd/rendertree/main_test.go
@@ -54,7 +54,7 @@ func TestRenderTree(t *testing.T) {
 			`+-----+-------------------------------------------------------------------------------------------+
 | ID  | Operator                                                                                  |
 +-----+-------------------------------------------------------------------------------------------+
-|   0 | Distributed Union on AlbumsByAlbumTitle <Row> (split_ranges_aligned: false)               |
+|   0 | Distributed Union on AlbumsByAlbumTitle <Row>                                             |
 |  *1 | +- Distributed Cross Apply <Row>                                                          |
 |   2 |    +- [Input] Create Batch <Row>                                                          |
 |   3 |    |  +- Local Distributed Union <Row>                                                    |
@@ -80,7 +80,7 @@ Predicates(identified by ID):
 			`+-----+-----------------------------------------------------------------------------+
 | ID  | Operator                                                                    |
 +-----+-----------------------------------------------------------------------------+
-|   0 | Distributed Union on AlbumsByAlbumTitle<Row>(split_ranges_aligned:false)    |
+|   0 | Distributed Union on AlbumsByAlbumTitle<Row>                                |
 |  *1 | +Distributed Cross Apply<Row>                                               |
 |   2 |  +[Input]Create Batch<Row>                                                  |
 |   3 |  |+Local Distributed Union<Row>                                             |
@@ -106,7 +106,7 @@ Predicates(identified by ID):
 			`+-----+-------------------------------------------------------------------------------------------+------+-------+------------+
 | ID  | Operator                                                                                  | Rows | Exec. | Latency    |
 +-----+-------------------------------------------------------------------------------------------+------+-------+------------+
-|   0 | Distributed Union on AlbumsByAlbumTitle <Row> (split_ranges_aligned: false)               |   33 |     1 | 1.92 msecs |
+|   0 | Distributed Union on AlbumsByAlbumTitle <Row>                                             |   33 |     1 | 1.92 msecs |
 |  *1 | +- Distributed Cross Apply <Row>                                                          |   33 |     1 |  1.9 msecs |
 |   2 |    +- [Input] Create Batch <Row>                                                          |      |       |            |
 |   3 |    |  +- Local Distributed Union <Row>                                                    |    7 |     1 | 0.95 msecs |
@@ -148,7 +148,7 @@ Predicates(identified by ID):
 			`+-----+-------------------------------------------------------------------------------------------+------+---------+----------+
 | ID  | Operator                                                                                  | Rows | Scanned | Filtered |
 +-----+-------------------------------------------------------------------------------------------+------+---------+----------+
-|   0 | Distributed Union on AlbumsByAlbumTitle <Row> (split_ranges_aligned: false)               |   33 |         |          |
+|   0 | Distributed Union on AlbumsByAlbumTitle <Row>                                             |   33 |         |          |
 |  *1 | +- Distributed Cross Apply <Row>                                                          |   33 |         |          |
 |   2 |    +- [Input] Create Batch <Row>                                                          |      |         |          |
 |   3 |    |  +- Local Distributed Union <Row>                                                    |    7 |         |          |
@@ -180,7 +180,7 @@ Predicates(identified by ID):
 			`+-----+-------------------------------------------------------------------------------------------+------+---------+----------+
 | ID  | Operator                                                                                  | Rows | Scanned | Filtered |
 +-----+-------------------------------------------------------------------------------------------+------+---------+----------+
-|   0 | Distributed Union on AlbumsByAlbumTitle <Row> (split_ranges_aligned: false)               |   33 |         |          |
+|   0 | Distributed Union on AlbumsByAlbumTitle <Row>                                             |   33 |         |          |
 |  *1 | +- Distributed Cross Apply <Row>                                                          |   33 |         |          |
 |   2 |    +- [Input] Create Batch <Row>                                                          |      |         |          |
 |   3 |    |  +- Local Distributed Union <Row>                                                    |    7 |         |          |
@@ -209,7 +209,7 @@ Predicates(identified by ID):
 		opts := []plantree.Option{plantree.WithQueryPlanOptions(
 			queryplan.WithTargetMetadataFormat(queryplan.TargetMetadataFormatOn),
 			queryplan.WithExecutionMethodFormat(queryplan.ExecutionMethodFormatAngle),
-			queryplan.WithFullScanFormat(queryplan.FullScanFormatLabel),
+			queryplan.WithKnownFlagFormat(queryplan.KnownFlagFormatLabel),
 		)}
 
 		if tcase.compact {

--- a/plantree/plantree.go
+++ b/plantree/plantree.go
@@ -9,8 +9,8 @@ import (
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/lox"
-	"github.com/samber/lo"
 	"github.com/apstndb/treeprint"
+	"github.com/samber/lo"
 
 	"github.com/apstndb/spannerplanviz/queryplan"
 	"github.com/apstndb/spannerplanviz/stats"

--- a/queryplan/queryplan.go
+++ b/queryplan/queryplan.go
@@ -216,12 +216,8 @@ func NodeTitle(node *sppb.PlanNode, opts ...Option) string {
 			if o.targetMetadataFormat != TargetMetadataFormatRaw {
 				continue
 			}
-		case "Full scan":
-			if o.knownFlagFormat != KnownFlagFormatRaw && v.GetStringValue() == "true" {
-				labels = append(labels, k)
-				continue
-			}
 		}
+
 		if o.knownFlagFormat != KnownFlagFormatRaw && slices.Contains([]string{"Full scan", "split_ranges_aligned"}, k) {
 			if v.GetStringValue() == "true" {
 				labels = append(labels, k)

--- a/queryplan/queryplan.go
+++ b/queryplan/queryplan.go
@@ -164,6 +164,8 @@ func EnableCompact() Option {
 	}
 }
 
+var knownBooleanFlagKeys = []string{"Full scan", "split_ranges_aligned"}
+
 func NodeTitle(node *sppb.PlanNode, opts ...Option) string {
 	var o option
 	for _, opt := range opts {
@@ -218,7 +220,7 @@ func NodeTitle(node *sppb.PlanNode, opts ...Option) string {
 			}
 		}
 
-		if o.knownFlagFormat != KnownFlagFormatRaw && slices.Contains([]string{"Full scan", "split_ranges_aligned"}, k) {
+		if o.knownFlagFormat != KnownFlagFormatRaw && slices.Contains(knownBooleanFlagKeys, k) {
 			if v.GetStringValue() == "true" {
 				labels = append(labels, k)
 			}

--- a/queryplan/queryplan.go
+++ b/queryplan/queryplan.go
@@ -3,6 +3,7 @@ package queryplan
 import (
 	"cmp"
 	"fmt"
+	"slices"
 	"sort"
 	"strings"
 
@@ -91,7 +92,7 @@ func (qp *QueryPlan) GetParentNodeByChildLink(link *sppb.PlanNode_ChildLink) *sp
 type option struct {
 	executionMethodFormat ExecutionMethodFormat
 	targetMetadataFormat  TargetMetadataFormat
-	fullScanFormat        FullScanFormat
+	knownFlagFormat       KnownFlagFormat
 	compact               bool
 }
 
@@ -117,14 +118,21 @@ const (
 	TargetMetadataFormatOn
 )
 
-type FullScanFormat int64
+type KnownFlagFormat int64
+type FullScanFormat = KnownFlagFormat
 
 const (
-	// FullScanFormatRaw prints Full scan metadata as is.
-	FullScanFormatRaw FullScanFormat = iota
+	// KnownFlagFormatRaw prints known boolean flag metadata as is.
+	KnownFlagFormatRaw KnownFlagFormat = iota
 
-	// FullScanFormatLabel prints Full scan metadata as "Full scan" without value.
-	FullScanFormatLabel
+	// KnownFlagFormatLabel prints known boolean flag metadata without value if true or omits if false.
+	KnownFlagFormatLabel
+
+	// Deprecated: FullScanFormatRaw is an alias of KnownFlagFormatRaw. (Deprecated)
+	FullScanFormatRaw = KnownFlagFormatRaw
+
+	// Deprecated: FullScanFormatLabel is an alias of KnownFlagFormatLabel. (Deprecated)
+	FullScanFormatLabel = KnownFlagFormatLabel
 )
 
 func WithExecutionMethodFormat(fmt ExecutionMethodFormat) Option {
@@ -139,10 +147,15 @@ func WithTargetMetadataFormat(fmt TargetMetadataFormat) Option {
 	}
 }
 
-func WithFullScanFormat(fmt FullScanFormat) Option {
+func WithKnownFlagFormat(fmt KnownFlagFormat) Option {
 	return func(o *option) {
-		o.fullScanFormat = fmt
+		o.knownFlagFormat = fmt
 	}
+}
+
+// Deprecated: WithFullScanFormat is an alias of WithKnownFlagFormat.
+func WithFullScanFormat(fmt FullScanFormat) Option {
+	return WithKnownFlagFormat(fmt)
 }
 
 func EnableCompact() Option {
@@ -176,8 +189,8 @@ func NodeTitle(node *sppb.PlanNode, opts ...Option) string {
 	executionMethodPart := lox.IfOrEmpty(o.executionMethodFormat == ExecutionMethodFormatAngle && len(executionMethod) > 0,
 		"<"+executionMethod+">")
 
-	var needFullscanToFront bool
-	fields := make([]string, 0)
+	var labels []string
+	var fields []string
 	for k, v := range metadataFields {
 		switch k {
 		case "call_type", "iterator_type": // Skip because it is displayed in node title
@@ -204,20 +217,24 @@ func NodeTitle(node *sppb.PlanNode, opts ...Option) string {
 				continue
 			}
 		case "Full scan":
-			if o.fullScanFormat != FullScanFormatRaw && v.GetStringValue() == "true" {
-				needFullscanToFront = true
+			if o.knownFlagFormat != KnownFlagFormatRaw && v.GetStringValue() == "true" {
+				labels = append(labels, k)
 				continue
 			}
+		}
+		if o.knownFlagFormat != KnownFlagFormatRaw && slices.Contains([]string{"Full scan", "split_ranges_aligned"}, k) {
+			if v.GetStringValue() == "true" {
+				labels = append(labels, k)
+			}
+			continue
 		}
 		fields = append(fields, fmt.Sprintf("%s:%s%s", k, sep, v.GetStringValue()))
 	}
 
+	sort.Strings(labels)
 	sort.Strings(fields)
-	if needFullscanToFront {
-		fields = append([]string{"Full scan"}, fields...)
-	}
 
-	return joinIfNotEmpty(sep, operator, executionMethodPart, encloseIfNotEmpty("(", strings.Join(fields, ","+sep), ")"))
+	return joinIfNotEmpty(sep, operator, executionMethodPart, encloseIfNotEmpty("(", strings.Join(slices.Concat(labels, fields), ","+sep), ")"))
 }
 
 func encloseIfNotEmpty(open, input, close string) string {


### PR DESCRIPTION
This PR implements `--known-flag`. It is enhancement of `--full-scan`.
If it is set to `LABEL` (default), the below known boolean metadata are printed as key-only label only if its value is `true`.

- `Full scan`
- `split_ranges_aligned`

This feature is also available as `queryplan.WithKnownFlagFormat`.

## `--known-flag=RAW`

```
$ execspansql ${SPANNER_DATABASE} --sql="SELECT * FROM Singers JOIN Albums USING (SingerId)" --query-mode=PROFILE --format=yaml | go run ./cmd/rendertree --compact --known-flag=RAW
+-----+-----------------------------------------------------------------------------+
| ID  | Operator                                                                    |
+-----+-----------------------------------------------------------------------------+
|   0 | Distributed Union on Singers<Row>(split_ranges_aligned:true)                |
|   1 | +Local Distributed Union<Row>                                               |
|   2 |  +Serialize Result<Row>                                                     |
|   3 |   +Cross Apply<Row>                                                         |
|   4 |    +[Input]Table Scan on Singers<Row>(Full scan:true,scan_method:Automatic) |
|  10 |    +[Map]Local Distributed Union<Row>                                       |
|  11 |     +Filter Scan<Row>(seekable_key_size:0)                                  |
| *12 |      +Table Scan on Albums<Row>(scan_method:Row)                            |
+-----+-----------------------------------------------------------------------------+
Predicates(identified by ID):
 12: Seek Condition: ($SingerId_1 = $SingerId)
```

###  `--known-flag=LABEL` (new default)
```
$ execspansql ${SPANNER_DATABASE} --sql="SELECT * FROM Singers JOIN Albums USING (SingerId)" --query-mode=PROFILE --format=yaml | go run ./cmd/rendertree --compact                 
+-----+------------------------------------------------------------------------+
| ID  | Operator                                                               |
+-----+------------------------------------------------------------------------+
|   0 | Distributed Union on Singers<Row>(split_ranges_aligned)                |
|   1 | +Local Distributed Union<Row>                                          |
|   2 |  +Serialize Result<Row>                                                |
|   3 |   +Cross Apply<Row>                                                    |
|   4 |    +[Input]Table Scan on Singers<Row>(Full scan,scan_method:Automatic) |
|  10 |    +[Map]Local Distributed Union<Row>                                  |
|  11 |     +Filter Scan<Row>(seekable_key_size:0)                             |
| *12 |      +Table Scan on Albums<Row>(scan_method:Row)                       |
+-----+------------------------------------------------------------------------+
Predicates(identified by ID):
 12: Seek Condition: ($SingerId_1 = $SingerId)
```