### PR TITLE
Add repository agent guidance

### DIFF
--- a/.gemini/config.yaml
+++ b/.gemini/config.yaml
@@ -1,0 +1,2 @@
+code_review:
+  comment_severity_threshold: HIGH

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+# Local scratch space for generated artifacts and temporary notes.
+.tmp/
+
+# Local editor and OS metadata.
+.DS_Store
+.idea/

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 # Local editor and OS metadata.
 .DS_Store
 .idea/
+
+# Local Go build output.
+spannerplanviz

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-This file provides guidance to Codex and other coding agents when working with code in this repository.
+This file provides guidance to AI coding agents when working with code in this repository.
 
 ## Project Overview
 
@@ -15,7 +15,7 @@ spannerplanviz is a Cloud Spanner Query Plan Visualizer that converts Spanner qu
 - **visualize/**: Core visualization logic
   - **visualize.go**: Main rendering coordinator, handles both Graphviz and Mermaid output paths
   - **mermaid.go**: Mermaid.js-specific rendering logic with structured configuration
-  - **build_tree.go**: Converts Spanner plan nodes into internal tree structure
+  - **build_tree.go**: Converts Spanner plan nodes into internal tree structure and defines node formatting logic for HTML and Mermaid labels
   - **util.go**: Utility functions for formatting and text processing
 
 ### Dependencies

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,8 +81,8 @@ Sample files in `visualize/testdata/` for testing:
 ## Code Conventions
 
 - Standard Go formatting with gofmt
-- Use struct methods for node operations (GetName(), HTML(), MermaidLabel())
-- Error wrapping with fmt.Errorf() for context
+- Follow existing tree node helper methods for node operations, such as GetName(), HTML(), and MermaidLabel()
+- Wrap errors with fmt.Errorf() and %w when preserving the underlying cause
 - Defer cleanup for resources (files, graphviz objects)
 - Use cgraph.EdgeStyle constants for edge styling
 - Mermaid output uses structured JSON configuration for theming

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# AGENTS.md
+
+This file provides guidance to Codex and other coding agents when working with code in this repository.
+
+## Project Overview
+
+spannerplanviz is a Cloud Spanner Query Plan Visualizer that converts Spanner query plans into visual diagrams using Graphviz and Mermaid.js. The tool reads JSON/YAML input containing Spanner query plans and generates visual output in various formats (SVG, PNG, DOT, Mermaid).
+
+## Architecture
+
+### Core Components
+
+- **main.go**: Entry point that parses CLI options, reads input, and orchestrates visualization
+- **option/options.go**: Defines CLI flags and options for controlling output format and content
+- **visualize/**: Core visualization logic
+  - **visualize.go**: Main rendering coordinator, handles both Graphviz and Mermaid output paths
+  - **mermaid.go**: Mermaid.js-specific rendering logic with structured configuration
+  - **build_tree.go**: Converts Spanner plan nodes into internal tree structure
+  - **util.go**: Utility functions for formatting and text processing
+
+### Dependencies
+
+- **github.com/apstndb/spannerplan**: External library for parsing Spanner query plans
+- **github.com/goccy/go-graphviz**: Graphviz rendering engine
+- **cloud.google.com/go/spanner**: Google Cloud Spanner client library for protobuf definitions
+- **github.com/jessevdk/go-flags**: CLI argument parsing
+
+### Input/Output Flow
+
+1. Input: JSON/YAML containing QueryPlan, ResultSetStats, or ResultSet from Spanner
+2. Parse using spannerplan.ExtractQueryPlan()
+3. Build internal tree structure via buildTree()
+4. Render output based on --type flag (svg/png/dot/mermaid)
+
+## Development Commands
+
+### Testing
+
+```bash
+make test
+# Or directly:
+go test -v ./...
+
+# Test with sample data:
+go run . --type=mermaid --full < visualize/testdata/dca_profile.json
+go run . --type=svg --full --output=test.svg < visualize/testdata/dca_profile.json
+```
+
+### Building
+
+```bash
+go build -o spannerplanviz .
+```
+
+### Running
+
+```bash
+# Basic usage - reads from stdin, outputs to stdout
+echo '{"queryPlan": {...}}' | go run . --type=svg
+
+# With file input/output
+go run . --input=plan.json --output=plan.svg --type=svg --full
+```
+
+### CLI Options
+
+- `--type`: Output format (svg, png, dot, mermaid)
+- `--full`: Enable all metadata options (execution-stats, metadata, etc.)
+- `--output`: Output file path
+- `--show-query`: Include query text in visualization
+- `--show-query-stats`: Include query statistics
+
+### Test Data
+
+Sample files in `visualize/testdata/` for testing:
+
+- `dca_profile.json`: Complex distributed cross apply query with profile data
+- `various_characters_profile.json`: Tests special character handling
+- `*.golden.mermaid`: Expected Mermaid output for regression testing
+
+## Code Conventions
+
+- Standard Go formatting with gofmt
+- Use struct methods for node operations (GetName(), HTML(), MermaidLabel())
+- Error wrapping with fmt.Errorf() for context
+- Defer cleanup for resources (files, graphviz objects)
+- Use cgraph.EdgeStyle constants for edge styling
+- Mermaid output uses structured JSON configuration for theming

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+@AGENTS.md

--- a/visualize/mermaid.go
+++ b/visualize/mermaid.go
@@ -53,8 +53,8 @@ func renderMermaid(rootNode *treeNode, writer io.Writer, qp *spannerplan.QueryPl
 		// Use the new MermaidLabel method
 		finalLabel := node.MermaidLabel(qp, param, rowType) // Pass qp, param, rowType
 
-		sb.WriteString(fmt.Sprintf("    %s[\"%s\"]\n", nodeName, finalLabel))
-		sb.WriteString(fmt.Sprintf("    style %s text-align:left;\n", nodeName))
+		fmt.Fprintf(&sb, "    %s[\"%s\"]\n", nodeName, finalLabel)
+		fmt.Fprintf(&sb, "    style %s text-align:left;\n", nodeName)
 
 		// Edges
 		for _, edgeLink := range node.Children {


### PR DESCRIPTION
## Summary
- Add `.gitignore` entries for local scratch space, editor metadata, macOS metadata, and the local `spannerplanviz` build output.
- Add `AGENTS.md` with repository-specific guidance for coding agents.
- Add `CLAUDE.md` as a thin pointer to `AGENTS.md`.
- Configure Gemini Code Assist repository review comments to `HIGH` severity or above via `.gemini/config.yaml`.
- Replace two Mermaid renderer `WriteString(fmt.Sprintf(...))` calls with `fmt.Fprintf` to satisfy the current golangci-lint/staticcheck rule.

## Validation
- `go test ./...`
- `mise x -- golangci-lint run --timeout=5m`

## Reference
- Gemini Code Assist repo review configuration: https://developers.google.com/gemini-code-assist/docs/customize-repo-review