### PR TITLE
Delegate plan stats and scalar links to spannerplan

### DIFF
--- a/visualize/build_tree.go
+++ b/visualize/build_tree.go
@@ -409,7 +409,7 @@ func (n *treeNode) GetStats(param option.Options) map[string]string {
 	if err != nil || es == nil {
 		return nil
 	}
-	return executionStatsToMap(es)
+	return executionStatsToMap(n.planNode, es)
 }
 
 func (n *treeNode) GetExecutionSummary(param option.Options) string {
@@ -421,7 +421,7 @@ func (n *treeNode) GetExecutionSummary(param option.Options) string {
 	if err != nil || es == nil {
 		return ""
 	}
-	return formatExecutionSummary(es.ExecutionSummary)
+	return formatExecutionSummary(n.planNode, es.ExecutionSummary)
 }
 
 // Metadata formats node content for GraphViz HTML-like labels.

--- a/visualize/build_tree.go
+++ b/visualize/build_tree.go
@@ -1,7 +1,6 @@
 package visualize
 
 import (
-	"bytes"
 	"fmt"
 	"html"
 	"maps"
@@ -14,6 +13,7 @@ import (
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/spannerplan"
+	"github.com/apstndb/spannerplan/plantree"
 	"github.com/goccy/go-graphviz/cgraph"
 	"google.golang.org/protobuf/types/known/structpb"
 	"sigs.k8s.io/yaml"
@@ -24,15 +24,15 @@ import (
 // This file contains logics which are purely formatting strings and building tree structures.
 // It is ok to depend on types in the cgraph package, but don't use graphviz.Graph in this file.
 
-func buildTree(qp *spannerplan.QueryPlan, planNode *sppb.PlanNode, rowType *sppb.StructType, param option.Options) (*treeNode, error) {
-	node, err := buildNode(planNode)
+func buildTree(qp *spannerplan.QueryPlan, planNode *sppb.PlanNode, rowType *sppb.StructType, param option.Options, rowsByID map[int32]plantree.RowWithPredicates) (*treeNode, error) {
+	node, err := buildNode(planNode, rowsByID)
 	if err != nil {
 		return nil, err
 	}
 
 	var edges []*link
 	for _, cl := range qp.VisibleChildLinks(planNode) {
-		childNode, err := buildTree(qp, qp.GetNodeByChildLink(cl), rowType, param)
+		childNode, err := buildTree(qp, qp.GetNodeByChildLink(cl), rowType, param, rowsByID)
 		if err != nil {
 			return nil, err
 		}
@@ -110,6 +110,7 @@ func isRemoteCall(node *sppb.PlanNode, cl *sppb.PlanNode_ChildLink) bool {
 type treeNode struct {
 	// Core data field
 	planNode *sppb.PlanNode
+	planRow  *plantree.RowWithPredicates
 
 	// Essential fields for graph structure
 	Children []*link
@@ -214,35 +215,34 @@ func (n *treeNode) getNodeContent(qp *spannerplan.QueryPlan, param option.Option
 		Title:               n.GetTitle(param),
 		ShortRepresentation: n.GetShortRepresentation(),
 		ScanInfo:            n.GetScanInfoOutput(param),
-		SerializeResult:     []string{}, // Initialize as empty slice
+		SerializeResult:     []string{},
 		NonVarScalarLinks:   []string{},
-		Metadata:            n.GetMetadata(param),
+		Metadata:            map[string]string{},
 		VarScalarLinks:      []string{},
 		Stats:               n.GetStats(param),
-		ExecutionSummary:    n.GetExecutionSummary(),
+		ExecutionSummary:    n.GetExecutionSummary(param),
 	}
 
-	// Handle multi-line outputs
-	if sroVal := n.GetSerializeResultOutput(qp, rowType); sroVal != "" {
-		for _, line := range strings.Split(strings.TrimSuffix(sroVal, "\n"), "\n") {
+	if param.Metadata {
+		content.Metadata = n.GetMetadata(param)
+	}
+
+	appendMultiline := func(target *[]string, value string) {
+		for _, line := range strings.Split(strings.TrimSuffix(value, "\n"), "\n") {
 			if line != "" {
-				content.SerializeResult = append(content.SerializeResult, line)
+				*target = append(*target, line)
 			}
 		}
 	}
-	if nvslVal := n.GetNonVarScalarLinksOutput(qp, param); nvslVal != "" {
-		for _, line := range strings.Split(strings.TrimSuffix(nvslVal, "\n"), "\n") {
-			if line != "" {
-				content.NonVarScalarLinks = append(content.NonVarScalarLinks, line)
-			}
-		}
+
+	if param.SerializeResult {
+		appendMultiline(&content.SerializeResult, n.GetSerializeResultOutput(rowType))
 	}
-	if vslVal := n.GetVarScalarLinksOutput(qp, param); vslVal != "" {
-		for _, line := range strings.Split(strings.TrimSuffix(vslVal, "\n"), "\n") {
-			if line != "" {
-				content.VarScalarLinks = append(content.VarScalarLinks, line)
-			}
-		}
+	if param.NonVariableScalar {
+		appendMultiline(&content.NonVarScalarLinks, n.GetNonVarScalarLinksOutput())
+	}
+	if param.VariableScalar {
+		appendMultiline(&content.VarScalarLinks, n.GetVarScalarLinksOutput())
 	}
 
 	// Apply heuristic check for ScanInfo double-printing
@@ -368,20 +368,25 @@ func (n *treeNode) GetScanInfoOutput(param option.Options) string {
 	return ""
 }
 
-func (n *treeNode) GetSerializeResultOutput(qp *spannerplan.QueryPlan, rowType *sppb.StructType) string {
-	if n.planNode.GetDisplayName() != "Serialize Result" {
+func (n *treeNode) GetSerializeResultOutput(rowType *sppb.StructType) string {
+	if n.planNode.GetDisplayName() != "Serialize Result" || n.planRow == nil {
 		return ""
 	}
-	// formatSerializeResult expects childLinkGroups which getNonVariableChildLinks provides
-	return formatSerializeResult(rowType, getNonVariableChildLinks(qp, n.planNode))
+	return formatSerializeResultFromLinks(rowType, n.planRow.ScalarChildLinks)
 }
 
-func (n *treeNode) GetNonVarScalarLinksOutput(qp *spannerplan.QueryPlan, param option.Options) string {
-	return formatChildLinks(getNonVariableChildLinks(qp, n.planNode))
+func (n *treeNode) GetNonVarScalarLinksOutput() string {
+	if n.planRow == nil {
+		return ""
+	}
+	return formatScalarChildLinks(filterScalarChildLinks(n.planRow.ScalarChildLinks, false))
 }
 
-func (n *treeNode) GetVarScalarLinksOutput(qp *spannerplan.QueryPlan, param option.Options) string {
-	return formatChildLinks(getVariableChildLinks(qp, n.planNode))
+func (n *treeNode) GetVarScalarLinksOutput() string {
+	if n.planRow == nil {
+		return ""
+	}
+	return formatScalarChildLinks(filterScalarChildLinks(n.planRow.ScalarChildLinks, true))
 }
 
 func (n *treeNode) GetMetadata(param option.Options) map[string]string {
@@ -396,36 +401,27 @@ func (n *treeNode) GetMetadata(param option.Options) map[string]string {
 }
 
 func (n *treeNode) GetStats(param option.Options) map[string]string {
-	if !param.ExecutionStats {
+	if !param.ExecutionStats || n.planNode == nil {
 		return nil
 	}
 
-	statsMap := make(map[string]string)
-	for key, valProto := range n.planNode.GetExecutionStats().GetFields() {
-		if key == "execution_summary" { // Skip summary for this map
-			continue
-		}
-
-		// Directly use formatExecutionStatsValue, assuming it's robust for stat structs
-		// formatExecutionStatsValue returns a string, not an error.
-		// It handles various fields within a stat struct.
-		// If valProto itself is not a struct, formatExecutionStatsValue might misbehave.
-		// It expects valProto to be the structpb.Value that IS the struct.
-		if valProto.GetStructValue() != nil {
-			statsMap[key] = formatExecutionStatsValue(valProto)
-		} else {
-			// If a top-level field in ExecutionStats is not a struct, it's unusual.
-			statsMap[key] = fmt.Sprint(valProto.AsInterface())
-		}
+	es, err := extractExecutionStats(n.planNode)
+	if err != nil || es == nil {
+		return nil
 	}
-	return statsMap
+	return executionStatsToMap(es)
 }
 
-func (n *treeNode) GetExecutionSummary() string {
-	if n.planNode == nil || n.planNode.GetExecutionStats() == nil {
+func (n *treeNode) GetExecutionSummary(param option.Options) string {
+	if !param.ExecutionSummary || n.planNode == nil {
 		return ""
 	}
-	return formatExecutionSummary(n.planNode.GetExecutionStats().GetFields())
+
+	es, err := extractExecutionStats(n.planNode)
+	if err != nil || es == nil {
+		return ""
+	}
+	return formatExecutionSummary(es.ExecutionSummary)
 }
 
 // Metadata formats node content for GraphViz HTML-like labels.
@@ -515,14 +511,16 @@ func (n *treeNode) HTML(qp *spannerplan.QueryPlan, param option.Options, rowType
 	return fmt.Sprintf(`%s<br align="CENTER"/>%s`, titleHTML, metadataHTML)
 }
 
-func buildNode(planNode *sppb.PlanNode) (*treeNode, error) {
+func buildNode(planNode *sppb.PlanNode, rowsByID map[int32]plantree.RowWithPredicates) (*treeNode, error) {
 	if planNode == nil {
 		return nil, fmt.Errorf("buildNode: received nil planNode")
 	}
 
-	return &treeNode{
+	node := &treeNode{
 		planNode: planNode,
-	}, nil
+	}
+	attachPlanRow(node, rowsByID)
+	return node, nil
 }
 
 // internalMetadataKeys lists metadata keys that are considered internal
@@ -533,38 +531,6 @@ var internalMetadataKeys = []string{
 	"scan_target",
 	"iterator_type",
 	"subquery_cluster_node",
-}
-
-func formatExecutionSummary(executionStatsFields map[string]*structpb.Value) string {
-	executionSummary, ok := executionStatsFields["execution_summary"]
-	if !ok {
-		return ""
-	}
-
-	var executionSummaryBuf bytes.Buffer
-	fmt.Fprintln(&executionSummaryBuf, "execution_summary:")
-	var executionSummaryStrings []string
-	for k, v := range executionSummary.GetStructValue().AsMap() {
-		var value string
-		// Only apply tryToTimestampStr to specific timestamp fields
-		if k == "execution_start_timestamp" || k == "execution_end_timestamp" {
-			formattedValue, err := tryToTimestampStr(fmt.Sprint(v))
-			if err != nil {
-				value = fmt.Sprintf("%s (error: %v)", fmt.Sprint(v), err)
-			} else {
-				value = formattedValue
-			}
-		} else {
-			value = fmt.Sprint(v)
-		}
-
-		const indentLevel = 3
-		executionSummaryStrings = append(executionSummaryStrings,
-			fmt.Sprintf("%s%s: %s\n", strings.Repeat(" ", indentLevel), k, value))
-	}
-	sort.Strings(executionSummaryStrings)
-	fmt.Fprint(&executionSummaryBuf, strings.Join(executionSummaryStrings, ""))
-	return executionSummaryBuf.String()
 }
 
 var newlineOrEOSRe = regexp.MustCompile(`\n?$|\n`)
@@ -608,117 +574,6 @@ func prefixIfNotEmpty(prefix, value string) string {
 	}
 
 	return prefix + value
-}
-
-func formatExecutionStatsValue(v *structpb.Value) string {
-	fields := v.GetStructValue().GetFields()
-	total := fields["total"].GetStringValue()
-	unit := fields["unit"].GetStringValue()
-	mean := fields["mean"].GetStringValue()
-	stdDev := fields["std_deviation"].GetStringValue()
-
-	stdDevStr := prefixIfNotEmpty("±", stdDev)
-	meanStr := prefixIfNotEmpty("@", mean+stdDevStr)
-	unitStr := prefixIfNotEmpty(" ", unit)
-
-	return fmt.Sprintf("%s%s%s", total, meanStr, unitStr)
-}
-
-type childLinkEntry struct {
-	Variable  string
-	PlanNodes *sppb.PlanNode
-}
-
-type childLinkGroup struct {
-	Type      string
-	PlanNodes []*childLinkEntry
-}
-
-func getScalarChildLinks(qp *spannerplan.QueryPlan, node *sppb.PlanNode, filter func(link *sppb.PlanNode_ChildLink) bool) []*childLinkGroup {
-	var result []*childLinkGroup
-	typeToChildLinks := make(map[string]*childLinkGroup)
-	for _, cl := range node.GetChildLinks() {
-		childNode := qp.GetNodeByChildLink(cl)
-		childType := cl.GetType()
-
-		if !filter(cl) || childNode.GetKind() != sppb.PlanNode_SCALAR {
-			continue
-		}
-		if _, ok := typeToChildLinks[childType]; !ok {
-			newEntry := &childLinkGroup{Type: childType}
-			typeToChildLinks[childType] = newEntry
-			result = append(result, newEntry)
-		}
-		childLinks := typeToChildLinks[childType]
-		childLinks.PlanNodes = append(childLinks.PlanNodes, &childLinkEntry{cl.GetVariable(), childNode})
-	}
-	return result
-}
-
-func getNonVariableChildLinks(plan *spannerplan.QueryPlan, node *sppb.PlanNode) []*childLinkGroup {
-	return getScalarChildLinks(plan, node, func(node *sppb.PlanNode_ChildLink) bool {
-		return node.GetVariable() == ""
-	})
-}
-
-func getVariableChildLinks(plan *spannerplan.QueryPlan, node *sppb.PlanNode) []*childLinkGroup {
-	return getScalarChildLinks(plan, node, func(node *sppb.PlanNode_ChildLink) bool {
-		return node.GetVariable() != ""
-	})
-}
-
-func formatChildLinks(childLinks []*childLinkGroup) string {
-	var buf bytes.Buffer
-	for _, cl := range childLinks {
-		var prefix string
-		if cl.Type != "" && cl.Type != "Value" {
-			if len(cl.PlanNodes) == 1 {
-				prefix = fmt.Sprintf("%s: ", cl.Type)
-			} else {
-				prefix = "  "
-				fmt.Fprintf(&buf, "%s:\n", cl.Type)
-			}
-		}
-		for _, childLinkEntry := range cl.PlanNodes {
-			if childLinkEntry.Variable == "" && cl.Type == "" {
-				continue
-			}
-
-			// it is safe even if nil receiver
-			description := childLinkEntry.PlanNodes.GetShortRepresentation().GetDescription()
-
-			if childLinkEntry.Variable == "" {
-				fmt.Fprintf(&buf, "%s%s\n", prefix, description)
-			} else {
-				fmt.Fprintf(&buf, "%s$%s:=%s\n", prefix, childLinkEntry.Variable, description)
-			}
-		}
-	}
-	return buf.String()
-}
-
-func formatSerializeResult(rowType *sppb.StructType, childLinks []*childLinkGroup) string {
-	var result bytes.Buffer
-	for _, cl := range childLinks {
-		if cl.Type != "" {
-			continue
-		}
-
-		for i, planNodeEntry := range cl.PlanNodes {
-			if rowType == nil || i >= len(rowType.GetFields()) {
-				continue
-			}
-			name := rowType.GetFields()[i].GetName()
-			if name == "" {
-				name = fmt.Sprintf("no_name<%d>", i)
-			}
-
-			description := planNodeEntry.PlanNodes.GetShortRepresentation().GetDescription()
-			text := fmt.Sprintf("Result.%s:%s", name, description)
-			fmt.Fprintln(&result, text)
-		}
-	}
-	return result.String()
 }
 
 func formatQueryStats(stats map[string]*structpb.Value) string {

--- a/visualize/build_tree_test.go
+++ b/visualize/build_tree_test.go
@@ -1,19 +1,47 @@
 package visualize
 
 import (
-	"fmt"
 	"testing"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/MakeNowJust/heredoc/v2"
 	"github.com/apstndb/spannerplan"
+	"github.com/apstndb/spannerplan/plantree"
 	"github.com/google/go-cmp/cmp"
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/proto"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/apstndb/spannerplanviz/option"
 )
+
+func applyTestOptions(opts option.Options) option.Options {
+	opts.ApplyFullOption()
+	return opts
+}
+
+func testBuildTree(t *testing.T, qp *spannerplan.QueryPlan, rowType *sppb.StructType, param option.Options) *treeNode {
+	t.Helper()
+
+	rowsByID, err := buildPlanRowIndex(qp)
+	if err != nil {
+		t.Fatalf("buildPlanRowIndex: %v", err)
+	}
+	rootNode, err := buildTree(qp, qp.GetNodeByIndex(0), rowType, param, rowsByID)
+	if err != nil {
+		t.Fatalf("buildTree: %v", err)
+	}
+	return rootNode
+}
+
+func planRowsFor(t *testing.T, qp *spannerplan.QueryPlan) map[int32]plantree.RowWithPredicates {
+	t.Helper()
+
+	rowsByID, err := buildPlanRowIndex(qp)
+	if err != nil {
+		t.Fatalf("buildPlanRowIndex: %v", err)
+	}
+	return rowsByID
+}
 
 func newTestQueryPlan(nodes []*sppb.PlanNode) (*spannerplan.QueryPlan, error) {
 	if len(nodes) == 0 {
@@ -28,6 +56,9 @@ func newTestQueryPlan(nodes []*sppb.PlanNode) (*spannerplan.QueryPlan, error) {
 	normalized := make([]*sppb.PlanNode, len(nodes))
 	for i, node := range nodes {
 		clone := proto.Clone(node).(*sppb.PlanNode)
+		if clone.GetKind() == sppb.PlanNode_KIND_UNSPECIFIED {
+			clone.Kind = sppb.PlanNode_RELATIONAL
+		}
 		clone.Index = int32(i)
 		for _, childLink := range clone.ChildLinks {
 			if childLink == nil {
@@ -39,6 +70,18 @@ func newTestQueryPlan(nodes []*sppb.PlanNode) (*spannerplan.QueryPlan, error) {
 	}
 
 	return spannerplan.New(normalized)
+}
+
+func normalizedNodeRef(qp *spannerplan.QueryPlan, sourceNodes []*sppb.PlanNode, target *sppb.PlanNode) *sppb.PlanNode {
+	if target == nil || qp == nil {
+		return target
+	}
+	for i, n := range sourceNodes {
+		if n.GetDisplayName() == target.GetDisplayName() && n.GetIndex() == target.GetIndex() {
+			return qp.GetNodeByIndex(int32(i))
+		}
+	}
+	return target
 }
 
 func TestToLeftAlignedText(t *testing.T) {
@@ -198,31 +241,31 @@ Full&nbsp;\:&nbsp;UsersTable`),
 		{
 			name: "Serialize Result Node",
 			planNodeProto: &sppb.PlanNode{
-				Index:       4,
+				Index:       0,
 				DisplayName: "Serialize Result",
 				ChildLinks: []*sppb.PlanNode_ChildLink{
-					// ChildIndex must refer to the index in the plan.Nodes slice.
-					// Node with original Index 100 is the second element (index 1) in nodesForPlan.
 					{ChildIndex: 1, Type: ""},
 				},
 			},
-			param: option.Options{TypeFlag: "mermaid"}, // SerializeResult is not gated by a top-level param in GetSerializeResultOutput
+			param: option.Options{TypeFlag: "mermaid", SerializeResult: true},
 			rowType: &sppb.StructType{
 				Fields: []*sppb.StructType_Field{
 					{Name: "userID", Type: &sppb.Type{Code: sppb.TypeCode_INT64}},
 				},
 			},
 			nodesForPlan: []*sppb.PlanNode{
-				{ // Index 0 in the slice for spannerplan.New
-					Index:       4, // Original index
+				{
+					Index:       0,
 					DisplayName: "Serialize Result",
 					ChildLinks: []*sppb.PlanNode_ChildLink{
-						{ChildIndex: 1, Type: ""}, // Corrected to point to the next node in the slice
+						{ChildIndex: 1, Type: ""},
 					},
 				},
-				{ // Index 1 in the slice for spannerplan.New
-					Index: 100, // Original index
-					Kind:  sppb.PlanNode_SCALAR, ShortRepresentation: &sppb.PlanNode_ShortRepresentation{Description: "U_ID"}},
+				{
+					Index: 1,
+					Kind:  sppb.PlanNode_SCALAR,
+					ShortRepresentation: &sppb.PlanNode_ShortRepresentation{Description: "U_ID"},
+				},
 			},
 			expectedMermaidLabel: heredoc.Doc(`<b>Serialize&nbsp;Result</b>
 Result\.userID\:U\_ID`),
@@ -321,8 +364,10 @@ Description&nbsp;with&nbsp;&quot;quotes&quot;&nbsp;and&nbsp;`) + "\\`backticks\\
 			// GetSerializeResultOutput, GetNonVarScalarLinksOutput, GetVarScalarLinksOutput do use qp.
 
 			node := &treeNode{
-				planNode: tc.planNodeProto,
-				// plan field is not directly part of treeNode anymore
+				planNode: normalizedNodeRef(currentPlan, nodesInTestPlan, tc.planNodeProto),
+			}
+			if currentPlan != nil {
+				attachPlanRow(node, planRowsFor(t, currentPlan))
 			}
 
 			// The MermaidLabel method itself handles the final quote escaping for the overall label.
@@ -361,7 +406,7 @@ func TestTreeNodeHTML(t *testing.T) {
 				Index:       1,
 				DisplayName: "Test Node Display Name",
 			},
-			param:        option.Options{Full: true},
+			param:        applyTestOptions(option.Options{Full: true}),
 			rowType:      nil,
 			expectedHTML: `<b>Test Node Display Name</b>`,
 		},
@@ -377,7 +422,7 @@ func TestTreeNodeHTML(t *testing.T) {
 					},
 				},
 			},
-			param:        option.Options{Full: true},
+			param:        applyTestOptions(option.Options{Full: true}),
 			rowType:      nil,
 			expectedHTML: `<b>Node With Meta</b><br align="CENTER"/>meta_key_1=meta_val_1<br align="left" />meta_key_2=123<br align="left" />`,
 		},
@@ -402,7 +447,7 @@ func TestTreeNodeHTML(t *testing.T) {
 					},
 				},
 			},
-			param:        option.Options{Full: true, ExecutionStats: true},
+			param:        applyTestOptions(option.Options{Full: true, ExecutionStats: true}),
 			rowType:      nil,
 			expectedHTML: `<b>Node With Stats</b><br align="CENTER"/><i>latency: 10s<br align="left" />rows: 100 rows<br align="left" /></i>`,
 		},
@@ -418,7 +463,7 @@ func TestTreeNodeHTML(t *testing.T) {
 					},
 				},
 			},
-			param:        option.Options{Full: true, HideScanTarget: false},
+			param:        applyTestOptions(option.Options{Full: true, HideScanTarget: false}),
 			rowType:      nil,
 			expectedHTML: `<b>Full scan Table Scan</b><br align="CENTER"/>Full scan: MyTable<br align="left" />`,
 		},
@@ -431,7 +476,7 @@ func TestTreeNodeHTML(t *testing.T) {
 					{ChildIndex: 0, Type: "Output"},
 				},
 			},
-			param: option.Options{Full: true},
+			param: applyTestOptions(option.Options{Full: true}),
 			rowType: &sppb.StructType{
 				Fields: []*sppb.StructType_Field{
 					{Name: "col1", Type: &sppb.Type{Code: sppb.TypeCode_STRING}},
@@ -450,20 +495,20 @@ func TestTreeNodeHTML(t *testing.T) {
 					{ChildIndex: 8, Type: "SCALAR", Variable: "scalar_var2"},
 				},
 			},
-			param:        option.Options{Full: true, NonVariableScalar: true},
+			param:        applyTestOptions(option.Options{Full: true, NonVariableScalar: true}),
 			rowType:      nil,
 			expectedHTML: `<b>Scalar Node</b>`,
 		},
 		{
 			name: "Node with Variable Scalar Child Links",
 			planNodeProto: &sppb.PlanNode{
-				Index:       9,
+				Index:       0,
 				DisplayName: "VarScalarOp",
 				ChildLinks: []*sppb.PlanNode_ChildLink{
-					{ChildIndex: 10, Type: "SCALAR", Variable: "var1"},
+					{ChildIndex: 1, Type: "SCALAR", Variable: "var1"},
 				},
 			},
-			param:        option.Options{Full: true, VariableScalar: true}, // VariableScalar is true
+			param:        applyTestOptions(option.Options{Full: true, VariableScalar: true}),
 			rowType:      nil,
 			expectedHTML: `<b>VarScalarOp</b><br align="CENTER"/>SCALAR: $var1:=Scalar Output<br align="left" />`,
 		},
@@ -474,29 +519,31 @@ func TestTreeNodeHTML(t *testing.T) {
 			nodesForPlan := []*sppb.PlanNode{}
 			switch tc.name {
 			case "Serialize Result Node":
-				// tc.planNode (Index 5) links to ChildIndex 0.
-				// For this case, ensure tc.planNode is included, and its direct reference.
-				// If spannerplan is slice-based, this might still be problematic if indices aren't dense.
-				nodesForPlan = append(nodesForPlan, tc.planNodeProto)
-				nodesForPlan = append(nodesForPlan, &sppb.PlanNode{Index: 0, DisplayName: "ChildForSerialize"})
+				nodesForPlan = append(nodesForPlan, &sppb.PlanNode{
+					Index:       0,
+					DisplayName: "Serialize Result",
+					ChildLinks: []*sppb.PlanNode_ChildLink{
+						{ChildIndex: 1, Type: "Output"},
+					},
+				})
+				nodesForPlan = append(nodesForPlan, &sppb.PlanNode{Index: 1, DisplayName: "ChildForSerialize", Kind: sppb.PlanNode_RELATIONAL})
 			case "Node with Scalar Child Links":
-				// tc.planNode (Index 6) links to ChildIndex 7 and 8.
-				// Re-applying dense slice hack assuming spannerplan might be slice-based.
-				for i := 0; i < 6; i++ { // Dummy nodes for 0-5
-					nodesForPlan = append(nodesForPlan, &sppb.PlanNode{Index: int32(i), DisplayName: fmt.Sprintf("Dummy %d", i)})
-				}
-				nodesForPlan = append(nodesForPlan, tc.planNodeProto)                                        // Actual node at Index 6
-				nodesForPlan = append(nodesForPlan, &sppb.PlanNode{Index: 7, DisplayName: "Scalar Child 1"}) // Actual node at Index 7
-				nodesForPlan = append(nodesForPlan, &sppb.PlanNode{Index: 8, DisplayName: "Scalar Child 2"}) // Actual node at Index 8
+				nodesForPlan = append(nodesForPlan, &sppb.PlanNode{
+					Index:       0,
+					DisplayName: "Scalar Node",
+					ChildLinks: []*sppb.PlanNode_ChildLink{
+						{ChildIndex: 1, Type: "SCALAR", Variable: "scalar_var1"},
+						{ChildIndex: 2, Type: "SCALAR", Variable: "scalar_var2"},
+					},
+				})
+				nodesForPlan = append(nodesForPlan,
+					&sppb.PlanNode{Index: 1, Kind: sppb.PlanNode_SCALAR, DisplayName: "Scalar Child 1"},
+					&sppb.PlanNode{Index: 2, Kind: sppb.PlanNode_SCALAR, DisplayName: "Scalar Child 2"},
+				)
 			case "Node with Variable Scalar Child Links":
-				// tc.planNode (Index 9) links to ChildIndex 10.
-				// Apply dense slice hack.
-				for i := 0; i < 9; i++ { // Dummy nodes for 0-8
-					nodesForPlan = append(nodesForPlan, &sppb.PlanNode{Index: int32(i), DisplayName: fmt.Sprintf("Dummy %d", i)})
-				}
-				nodesForPlan = append(nodesForPlan, tc.planNodeProto) // Actual node at Index 9
-				nodesForPlan = append(nodesForPlan, &sppb.PlanNode{ // Actual Scalar Child for Var
-					Index:               10,
+				nodesForPlan = append(nodesForPlan, tc.planNodeProto)
+				nodesForPlan = append(nodesForPlan, &sppb.PlanNode{
+					Index:               1,
 					Kind:                sppb.PlanNode_SCALAR,
 					DisplayName:         "ScalarFunc",
 					ShortRepresentation: &sppb.PlanNode_ShortRepresentation{Description: "Scalar Output"},
@@ -516,15 +563,11 @@ func TestTreeNodeHTML(t *testing.T) {
 			}
 
 			node := &treeNode{
-				planNode: tc.planNodeProto,
-				// plan and Name fields removed
+				planNode: normalizedNodeRef(currentPlan, nodesForPlan, tc.planNodeProto),
 			}
-			// Tooltip is now via GetTooltip, not directly set or checked here unless specific to HTML output.
-			// The HTML method itself calls GetTooltip. If we need to check tooltip content,
-			// it would be via node.GetTooltip() directly, not as part of node.HTML() test unless it affects HTML.
-			// For now, ensure HTML() can be called.
+			attachPlanRow(node, planRowsFor(t, currentPlan))
 
-			gotHTML := node.HTML(currentPlan, tc.param, tc.rowType) // Pass currentPlan
+			gotHTML := node.HTML(currentPlan, tc.param, tc.rowType)
 			if diff := cmp.Diff(tc.expectedHTML, gotHTML); diff != "" {
 				t.Errorf("HTML() mismatch for test case %q (-expected +actual):\n%s", tc.name, diff)
 			}
@@ -672,154 +715,6 @@ func TestTryToTimestampStr(t *testing.T) {
 				if diff := cmp.Diff(got, tt.want); diff != "" {
 					t.Errorf("tryToTimestampStr() mismatch (-got +want):\n%s", diff)
 				}
-			}
-		})
-	}
-}
-
-func TestFormatExecutionStatsValue(t *testing.T) {
-	tests := []struct {
-		name  string
-		input *structpb.Value
-		want  string
-	}{
-		{
-			name: "all fields present",
-			input: structpb.NewStructValue(&structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"total":         structpb.NewStringValue("100"),
-					"unit":          structpb.NewStringValue("rows"),
-					"mean":          structpb.NewStringValue("10"),
-					"std_deviation": structpb.NewStringValue("2"),
-				},
-			}),
-			want: "100@10±2 rows",
-		},
-		{
-			name: "no std_deviation",
-			input: structpb.NewStructValue(&structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"total":         structpb.NewStringValue("50"),
-					"unit":          structpb.NewStringValue("bytes"),
-					"mean":          structpb.NewStringValue("5"),
-					"std_deviation": structpb.NewStringValue(""),
-				},
-			}),
-			want: "50@5 bytes",
-		},
-		{
-			name: "no mean or std_deviation",
-			input: structpb.NewStructValue(&structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"total":         structpb.NewStringValue("200"),
-					"unit":          structpb.NewStringValue("ms"),
-					"mean":          structpb.NewStringValue(""),
-					"std_deviation": structpb.NewStringValue(""),
-				},
-			}),
-			want: "200 ms",
-		},
-		{
-			name: "empty struct",
-			input: structpb.NewStructValue(&structpb.Struct{
-				Fields: map[string]*structpb.Value{},
-			}),
-			want: "",
-		},
-		{
-			name: "all fields empty strings",
-			input: structpb.NewStructValue(&structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"total":         structpb.NewStringValue(""),
-					"unit":          structpb.NewStringValue(""),
-					"mean":          structpb.NewStringValue(""),
-					"std_deviation": structpb.NewStringValue(""),
-				},
-			}),
-			want: "",
-		},
-		{
-			name: "missing total",
-			input: structpb.NewStructValue(&structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"unit":          structpb.NewStringValue("rows"),
-					"mean":          structpb.NewStringValue("10"),
-					"std_deviation": structpb.NewStringValue("2"),
-				},
-			}),
-			want: "@10±2 rows",
-		},
-		{
-			name: "missing unit",
-			input: structpb.NewStructValue(&structpb.Struct{
-				Fields: map[string]*structpb.Value{
-					"total":         structpb.NewStringValue("100"),
-					"mean":          structpb.NewStringValue("10"),
-					"std_deviation": structpb.NewStringValue("2"),
-				},
-			}),
-			want: "100@10±2",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got := formatExecutionStatsValue(tt.input)
-			if diff := cmp.Diff(got, tt.want); diff != "" {
-				t.Errorf("formatExecutionStatsValue() mismatch (-got +want):\n%s", diff)
-			}
-		})
-	}
-}
-
-func TestTreeNodeGetStats(t *testing.T) {
-	tests := []struct {
-		name     string
-		planNode *sppb.PlanNode
-		param    option.Options
-		want     map[string]string
-	}{
-		{
-			name: "Node with stats",
-			planNode: &sppb.PlanNode{
-				ExecutionStats: &structpb.Struct{
-					Fields: map[string]*structpb.Value{
-						"cpu_time": structpb.NewStructValue(&structpb.Struct{
-							Fields: map[string]*structpb.Value{"total": structpb.NewStringValue("10ms")},
-						}),
-						"rows_returned": structpb.NewStructValue(&structpb.Struct{
-							Fields: map[string]*structpb.Value{"total": structpb.NewStringValue("100")},
-						}),
-						"execution_summary": structpb.NewStringValue("summary_text"), // Should be ignored
-					},
-				},
-			},
-			param: option.Options{ExecutionStats: true},
-			want: map[string]string{
-				"cpu_time":      "10ms",
-				"rows_returned": "100",
-			},
-		},
-		{
-			name:     "Node with no stats",
-			planNode: &sppb.PlanNode{},
-			param:    option.Options{},
-			want:     map[string]string{},
-		},
-		{
-			name:     "Nil plan node",
-			planNode: nil,
-			param:    option.Options{},
-			want:     map[string]string{},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			node := &treeNode{planNode: tt.planNode}
-			got := node.GetStats(tt.param)
-			if diff := cmp.Diff(got, tt.want, cmpopts.EquateEmpty()); diff != "" {
-				t.Errorf("GetStats() mismatch (-got +want):\n%s", diff)
 			}
 		})
 	}

--- a/visualize/build_tree_test.go
+++ b/visualize/build_tree_test.go
@@ -22,9 +22,9 @@ func applyTestOptions(opts option.Options) option.Options {
 func testBuildTree(t *testing.T, qp *spannerplan.QueryPlan, rowType *sppb.StructType, param option.Options) *treeNode {
 	t.Helper()
 
-	rowsByID, err := buildPlanRowIndex(qp)
+	rowsByID, err := buildScalarLinkRowIndex(qp, param)
 	if err != nil {
-		t.Fatalf("buildPlanRowIndex: %v", err)
+		t.Fatalf("buildScalarLinkRowIndex: %v", err)
 	}
 	rootNode, err := buildTree(qp, qp.GetNodeByIndex(0), rowType, param, rowsByID)
 	if err != nil {

--- a/visualize/scalar_links.go
+++ b/visualize/scalar_links.go
@@ -1,0 +1,110 @@
+package visualize
+
+import (
+	"bytes"
+	"fmt"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spannerplan"
+	"github.com/apstndb/spannerplan/plantree"
+)
+
+func buildPlanRowIndex(qp *spannerplan.QueryPlan) (map[int32]plantree.RowWithPredicates, error) {
+	rows, err := plantree.ProcessPlan(qp, plantree.WithQueryPlanOptions(spannerplan.HideMetadata()))
+	if err != nil {
+		return nil, err
+	}
+
+	rowsByID := make(map[int32]plantree.RowWithPredicates, len(rows))
+	for _, row := range rows {
+		rowsByID[row.ID] = row
+	}
+	return rowsByID, nil
+}
+
+func attachPlanRow(node *treeNode, rowsByID map[int32]plantree.RowWithPredicates) {
+	if node == nil || node.planNode == nil || rowsByID == nil {
+		return
+	}
+	if row, ok := rowsByID[node.planNode.GetIndex()]; ok {
+		rowCopy := row
+		node.planRow = &rowCopy
+	}
+}
+
+func filterScalarChildLinks(links []plantree.ScalarChildLink, variableOnly bool) []plantree.ScalarChildLink {
+	var result []plantree.ScalarChildLink
+	for _, link := range links {
+		hasVariable := link.Variable != ""
+		if variableOnly && !hasVariable {
+			continue
+		}
+		if !variableOnly && hasVariable {
+			continue
+		}
+		result = append(result, link)
+	}
+	return result
+}
+
+func formatScalarChildLinks(links []plantree.ScalarChildLink) string {
+	var buf bytes.Buffer
+	typeOrder := make([]string, 0)
+	groups := make(map[string][]plantree.ScalarChildLink)
+
+	for _, link := range links {
+		if link.Variable == "" && link.Type == "" {
+			continue
+		}
+		if _, ok := groups[link.Type]; !ok {
+			typeOrder = append(typeOrder, link.Type)
+		}
+		groups[link.Type] = append(groups[link.Type], link)
+	}
+
+	for _, typ := range typeOrder {
+		entries := groups[typ]
+		var prefix string
+		if typ != "" && typ != "Value" {
+			if len(entries) == 1 {
+				prefix = fmt.Sprintf("%s: ", typ)
+			} else {
+				prefix = "  "
+				fmt.Fprintf(&buf, "%s:\n", typ)
+			}
+		}
+		for _, link := range entries {
+			if link.Variable == "" {
+				fmt.Fprintf(&buf, "%s%s\n", prefix, link.Description)
+			} else {
+				fmt.Fprintf(&buf, "%s$%s:=%s\n", prefix, link.Variable, link.Description)
+			}
+		}
+	}
+	return buf.String()
+}
+
+func serializeResultScalarLinks(links []plantree.ScalarChildLink) []plantree.ScalarChildLink {
+	var result []plantree.ScalarChildLink
+	for _, link := range links {
+		if link.Variable == "" && link.Type == "" {
+			result = append(result, link)
+		}
+	}
+	return result
+}
+
+func formatSerializeResultFromLinks(rowType *sppb.StructType, links []plantree.ScalarChildLink) string {
+	var result bytes.Buffer
+	for i, link := range serializeResultScalarLinks(links) {
+		if rowType == nil || i >= len(rowType.GetFields()) {
+			continue
+		}
+		name := rowType.GetFields()[i].GetName()
+		if name == "" {
+			name = fmt.Sprintf("no_name<%d>", i)
+		}
+		fmt.Fprintf(&result, "Result.%s:%s\n", name, link.Description)
+	}
+	return result.String()
+}

--- a/visualize/scalar_links.go
+++ b/visualize/scalar_links.go
@@ -7,7 +7,20 @@ import (
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/spannerplan"
 	"github.com/apstndb/spannerplan/plantree"
+
+	"github.com/apstndb/spannerplanviz/option"
 )
+
+func buildScalarLinkRowIndex(qp *spannerplan.QueryPlan, param option.Options) (map[int32]plantree.RowWithPredicates, error) {
+	if !needsScalarLinkRows(param) {
+		return nil, nil
+	}
+	return buildPlanRowIndex(qp)
+}
+
+func needsScalarLinkRows(param option.Options) bool {
+	return param.SerializeResult || param.NonVariableScalar || param.VariableScalar
+}
 
 func buildPlanRowIndex(qp *spannerplan.QueryPlan) (map[int32]plantree.RowWithPredicates, error) {
 	rows, err := plantree.ProcessPlan(qp, plantree.WithQueryPlanOptions(spannerplan.HideMetadata()))

--- a/visualize/scalar_links_test.go
+++ b/visualize/scalar_links_test.go
@@ -1,0 +1,163 @@
+package visualize
+
+import (
+	"testing"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spannerplan"
+	"github.com/apstndb/spannerplan/plantree"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestFormatScalarChildLinks(t *testing.T) {
+	tests := []struct {
+		name  string
+		links []plantree.ScalarChildLink
+		want  string
+	}{
+		{
+			name: "variable scalar with type",
+			links: []plantree.ScalarChildLink{
+				{Type: "SCALAR", Variable: "var1", Description: "Scalar Output"},
+			},
+			want: "SCALAR: $var1:=Scalar Output\n",
+		},
+		{
+			name: "non-variable with type prefix for multiple entries",
+			links: []plantree.ScalarChildLink{
+				{Type: "Key", Description: "col_a"},
+				{Type: "Key", Description: "col_b"},
+			},
+			want: "Key:\n  col_a\n  col_b\n",
+		},
+		{
+			name: "skip empty type and variable",
+			links: []plantree.ScalarChildLink{
+				{Description: "ignored"},
+				{Type: "Condition", Description: "x = 1"},
+			},
+			want: "Condition: x = 1\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatScalarChildLinks(tt.links)
+			if diff := cmp.Diff(tt.want, got); diff != "" {
+				t.Errorf("formatScalarChildLinks() mismatch (-want +got):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestFilterScalarChildLinks(t *testing.T) {
+	links := []plantree.ScalarChildLink{
+		{Type: "Value", Description: "plain"},
+		{Type: "SCALAR", Variable: "v", Description: "assigned"},
+	}
+
+	gotNonVar := filterScalarChildLinks(links, false)
+	gotVar := filterScalarChildLinks(links, true)
+
+	if len(gotNonVar) != 1 || gotNonVar[0].Description != "plain" {
+		t.Fatalf("filterScalarChildLinks(false) = %#v, want plain link only", gotNonVar)
+	}
+	if len(gotVar) != 1 || gotVar[0].Variable != "v" {
+		t.Fatalf("filterScalarChildLinks(true) = %#v, want variable link only", gotVar)
+	}
+}
+
+func TestFormatSerializeResultFromLinks(t *testing.T) {
+	rowType := &sppb.StructType{
+		Fields: []*sppb.StructType_Field{
+			{Name: "userID", Type: &sppb.Type{Code: sppb.TypeCode_INT64}},
+		},
+	}
+	links := []plantree.ScalarChildLink{
+		{Description: "U_ID"},
+		{Type: "Key", Description: "ignored"},
+	}
+
+	got := formatSerializeResultFromLinks(rowType, links)
+	want := "Result.userID:U_ID\n"
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("formatSerializeResultFromLinks() mismatch (-want +got):\n%s", diff)
+	}
+}
+
+func TestBuildPlanRowIndex(t *testing.T) {
+	nodes := []*sppb.PlanNode{
+		{
+			Index:       0,
+			DisplayName: "VarScalarOp",
+			Kind:        sppb.PlanNode_RELATIONAL,
+			ChildLinks: []*sppb.PlanNode_ChildLink{
+				{ChildIndex: 1, Type: "SCALAR", Variable: "var1"},
+			},
+		},
+		{
+			Index:               1,
+			Kind:                sppb.PlanNode_SCALAR,
+			ShortRepresentation: &sppb.PlanNode_ShortRepresentation{Description: "Scalar Output"},
+		},
+	}
+
+	qp, err := spannerplan.New(nodes)
+	if err != nil {
+		t.Fatalf("spannerplan.New() error = %v", err)
+	}
+
+	rowsByID, err := buildPlanRowIndex(qp)
+	if err != nil {
+		t.Fatalf("buildPlanRowIndex() error = %v", err)
+	}
+
+	row, ok := rowsByID[0]
+	if !ok {
+		t.Fatal("expected row for node 0")
+	}
+	if len(row.ScalarChildLinks) != 1 {
+		t.Fatalf("ScalarChildLinks = %#v, want one link", row.ScalarChildLinks)
+	}
+	if row.ScalarChildLinks[0].Variable != "var1" {
+		t.Fatalf("ScalarChildLinks[0].Variable = %q, want var1", row.ScalarChildLinks[0].Variable)
+	}
+}
+
+func TestTreeNodeScalarLinksFromPlanRow(t *testing.T) {
+	nodes := []*sppb.PlanNode{
+		{
+			Index:       0,
+			DisplayName: "VarScalarOp",
+			Kind:        sppb.PlanNode_RELATIONAL,
+			ChildLinks: []*sppb.PlanNode_ChildLink{
+				{ChildIndex: 1, Type: "SCALAR", Variable: "var1"},
+			},
+		},
+		{
+			Index:               1,
+			Kind:                sppb.PlanNode_SCALAR,
+			ShortRepresentation: &sppb.PlanNode_ShortRepresentation{Description: "Scalar Output"},
+		},
+	}
+
+	qp, err := spannerplan.New(nodes)
+	if err != nil {
+		t.Fatalf("spannerplan.New() error = %v", err)
+	}
+	rowsByID, err := buildPlanRowIndex(qp)
+	if err != nil {
+		t.Fatalf("buildPlanRowIndex() error = %v", err)
+	}
+
+	node, err := buildNode(nodes[0], rowsByID)
+	if err != nil {
+		t.Fatalf("buildNode() error = %v", err)
+	}
+
+	got := node.GetVarScalarLinksOutput()
+	want := "SCALAR: $var1:=Scalar Output\n"
+	if diff := cmp.Diff(want, got); diff != "" {
+		t.Errorf("GetVarScalarLinksOutput() mismatch (-want +got):\n%s", diff)
+	}
+}

--- a/visualize/scalar_links_test.go
+++ b/visualize/scalar_links_test.go
@@ -71,15 +71,17 @@ func TestFormatSerializeResultFromLinks(t *testing.T) {
 	rowType := &sppb.StructType{
 		Fields: []*sppb.StructType_Field{
 			{Name: "userID", Type: &sppb.Type{Code: sppb.TypeCode_INT64}},
+			{Name: "", Type: &sppb.Type{Code: sppb.TypeCode_STRING}},
 		},
 	}
 	links := []plantree.ScalarChildLink{
-		{Description: "U_ID"},
 		{Type: "Key", Description: "ignored"},
+		{Description: "U_ID"},
+		{Description: "U_NAME"},
 	}
 
 	got := formatSerializeResultFromLinks(rowType, links)
-	want := "Result.userID:U_ID\n"
+	want := "Result.userID:U_ID\nResult.no_name<1>:U_NAME\n"
 	if diff := cmp.Diff(want, got); diff != "" {
 		t.Errorf("formatSerializeResultFromLinks() mismatch (-want +got):\n%s", diff)
 	}

--- a/visualize/stats_format.go
+++ b/visualize/stats_format.go
@@ -8,6 +8,7 @@ import (
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
 	"github.com/apstndb/spannerplan/stats"
+	"google.golang.org/protobuf/types/known/structpb"
 )
 
 type executionStatField struct {
@@ -41,7 +42,7 @@ func extractExecutionStats(node *sppb.PlanNode) (*stats.ExecutionStats, error) {
 	return stats.Extract(node, false)
 }
 
-func executionStatsToMap(es *stats.ExecutionStats) map[string]string {
+func executionStatsToMap(node *sppb.PlanNode, es *stats.ExecutionStats) map[string]string {
 	if es == nil {
 		return nil
 	}
@@ -52,7 +53,54 @@ func executionStatsToMap(es *stats.ExecutionStats) map[string]string {
 			statsMap[field.key] = formatted
 		}
 	}
+	mergeUnknownExecutionStats(node, statsMap)
 	return statsMap
+}
+
+func knownExecutionStatKeys() map[string]struct{} {
+	keys := make(map[string]struct{}, len(executionStatFields(stats.ExecutionStats{}))+1)
+	for _, field := range executionStatFields(stats.ExecutionStats{}) {
+		keys[field.key] = struct{}{}
+	}
+	keys["execution_summary"] = struct{}{}
+	return keys
+}
+
+func mergeUnknownExecutionStats(node *sppb.PlanNode, statsMap map[string]string) {
+	if node == nil || statsMap == nil {
+		return
+	}
+
+	knownKeys := knownExecutionStatKeys()
+	for key, valProto := range node.GetExecutionStats().GetFields() {
+		if key == "execution_summary" {
+			continue
+		}
+		if _, ok := statsMap[key]; ok {
+			continue
+		}
+		if _, known := knownKeys[key]; known {
+			continue
+		}
+		if formatted := formatExecutionStatsValueFromProto(valProto); formatted != "" {
+			statsMap[key] = formatted
+		} else {
+			statsMap[key] = fmt.Sprint(valProto.AsInterface())
+		}
+	}
+}
+
+func formatExecutionStatsValueFromProto(v *structpb.Value) string {
+	if v.GetStructValue() == nil {
+		return ""
+	}
+	fields := v.GetStructValue().GetFields()
+	return formatExecutionStatsValue(stats.ExecutionStatsValue{
+		Total:        fields["total"].GetStringValue(),
+		Unit:         fields["unit"].GetStringValue(),
+		Mean:         fields["mean"].GetStringValue(),
+		StdDeviation: fields["std_deviation"].GetStringValue(),
+	})
 }
 
 func formatExecutionStatsValue(v stats.ExecutionStatsValue) string {
@@ -63,46 +111,71 @@ func formatExecutionStatsValue(v stats.ExecutionStatsValue) string {
 	return fmt.Sprintf("%s%s%s", v.Total, meanStr, unitStr)
 }
 
-func formatExecutionSummary(summary stats.ExecutionStatsSummary) string {
-	type summaryField struct {
-		key   string
-		value string
-	}
+func formatExecutionSummary(node *sppb.PlanNode, summary stats.ExecutionStatsSummary) string {
+	lines := typedExecutionSummaryLines(summary)
+	mergeUnknownExecutionSummaryLines(node, lines)
+	return renderExecutionSummaryLines(lines)
+}
 
-	fields := []summaryField{
-		{"checkpoint_time", summary.CheckpointTime},
-		{"execution_end_timestamp", summary.ExecutionEndTimestamp},
-		{"execution_start_timestamp", summary.ExecutionStartTimestamp},
-		{"num_checkpoints", summary.NumCheckPoints.String()},
-		{"num_executions", summary.NumExecutions},
-	}
+func typedExecutionSummaryLines(summary stats.ExecutionStatsSummary) map[string]string {
+	lines := make(map[string]string)
 
-	var executionSummaryStrings []string
-	for _, field := range fields {
-		if field.value == "" {
-			continue
+	setLine := func(key, value string) {
+		if value == "" {
+			return
 		}
-
-		value := field.value
-		if field.key == "execution_start_timestamp" || field.key == "execution_end_timestamp" {
-			formattedValue, err := tryToTimestampStr(field.value)
+		if key == "execution_start_timestamp" || key == "execution_end_timestamp" {
+			formattedValue, err := tryToTimestampStr(value)
 			if err != nil {
-				value = fmt.Sprintf("%s (error: %v)", field.value, err)
+				value = fmt.Sprintf("%s (error: %v)", value, err)
 			} else {
 				value = formattedValue
 			}
 		}
-
-		const indentLevel = 3
-		executionSummaryStrings = append(executionSummaryStrings,
-			fmt.Sprintf("%s%s: %s\n", strings.Repeat(" ", indentLevel), field.key, value))
+		lines[key] = value
 	}
 
-	if len(executionSummaryStrings) == 0 {
+	setLine("checkpoint_time", summary.CheckpointTime)
+	setLine("execution_end_timestamp", summary.ExecutionEndTimestamp)
+	setLine("execution_start_timestamp", summary.ExecutionStartTimestamp)
+	setLine("num_checkpoints", summary.NumCheckPoints.String())
+	setLine("num_executions", summary.NumExecutions)
+	return lines
+}
+
+func mergeUnknownExecutionSummaryLines(node *sppb.PlanNode, lines map[string]string) {
+	if node == nil || lines == nil {
+		return
+	}
+	rawSummary, ok := node.GetExecutionStats().GetFields()["execution_summary"]
+	if !ok || rawSummary.GetStructValue() == nil {
+		return
+	}
+	for key, valProto := range rawSummary.GetStructValue().GetFields() {
+		if _, exists := lines[key]; exists {
+			continue
+		}
+		lines[key] = fmt.Sprint(valProto.AsInterface())
+	}
+}
+
+func renderExecutionSummaryLines(lines map[string]string) string {
+	if len(lines) == 0 {
 		return ""
 	}
 
-	sort.Strings(executionSummaryStrings)
+	keys := make([]string, 0, len(lines))
+	for key := range lines {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+
+	var executionSummaryStrings []string
+	for _, key := range keys {
+		const indentLevel = 3
+		executionSummaryStrings = append(executionSummaryStrings,
+			fmt.Sprintf("%s%s: %s\n", strings.Repeat(" ", indentLevel), key, lines[key]))
+	}
 
 	var executionSummaryBuf bytes.Buffer
 	fmt.Fprintln(&executionSummaryBuf, "execution_summary:")

--- a/visualize/stats_format.go
+++ b/visualize/stats_format.go
@@ -1,0 +1,111 @@
+package visualize
+
+import (
+	"bytes"
+	"fmt"
+	"sort"
+	"strings"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spannerplan/stats"
+)
+
+type executionStatField struct {
+	key string
+	val stats.ExecutionStatsValue
+}
+
+func executionStatFields(es stats.ExecutionStats) []executionStatField {
+	return []executionStatField{
+		{"Disk Usage (KBytes)", es.DiskUsageKBytes},
+		{"Disk Write Latency (msecs)", es.DiskWriteLatencyMsecs},
+		{"Peak Buffering Memory Usage (KBytes)", es.PeekBufferingMemoryUsageKBytes},
+		{"Peak Memory Usage (KBytes)", es.PeakMemoryUsageKBytes},
+		{"Rows Spooled", es.RowsSpooled},
+		{"Number of Batches", es.NumberOfBatches},
+		{"cpu_time", es.CpuTime},
+		{"deleted_rows", es.DeletedRows},
+		{"filesystem_delay_seconds", es.FilesystemDelaySeconds},
+		{"filtered_rows", es.FilteredRows},
+		{"latency", es.Latency},
+		{"remote_calls", es.RemoteCalls},
+		{"rows", es.Rows},
+		{"scanned_rows", es.ScannedRows},
+	}
+}
+
+func extractExecutionStats(node *sppb.PlanNode) (*stats.ExecutionStats, error) {
+	if node == nil || node.GetExecutionStats() == nil {
+		return nil, nil
+	}
+	return stats.Extract(node, false)
+}
+
+func executionStatsToMap(es *stats.ExecutionStats) map[string]string {
+	if es == nil {
+		return nil
+	}
+
+	statsMap := make(map[string]string)
+	for _, field := range executionStatFields(*es) {
+		if formatted := formatExecutionStatsValue(field.val); formatted != "" {
+			statsMap[field.key] = formatted
+		}
+	}
+	return statsMap
+}
+
+func formatExecutionStatsValue(v stats.ExecutionStatsValue) string {
+	stdDevStr := prefixIfNotEmpty("±", v.StdDeviation)
+	meanStr := prefixIfNotEmpty("@", v.Mean+stdDevStr)
+	unitStr := prefixIfNotEmpty(" ", v.Unit)
+
+	return fmt.Sprintf("%s%s%s", v.Total, meanStr, unitStr)
+}
+
+func formatExecutionSummary(summary stats.ExecutionStatsSummary) string {
+	type summaryField struct {
+		key   string
+		value string
+	}
+
+	fields := []summaryField{
+		{"checkpoint_time", summary.CheckpointTime},
+		{"execution_end_timestamp", summary.ExecutionEndTimestamp},
+		{"execution_start_timestamp", summary.ExecutionStartTimestamp},
+		{"num_checkpoints", summary.NumCheckPoints.String()},
+		{"num_executions", summary.NumExecutions},
+	}
+
+	var executionSummaryStrings []string
+	for _, field := range fields {
+		if field.value == "" {
+			continue
+		}
+
+		value := field.value
+		if field.key == "execution_start_timestamp" || field.key == "execution_end_timestamp" {
+			formattedValue, err := tryToTimestampStr(field.value)
+			if err != nil {
+				value = fmt.Sprintf("%s (error: %v)", field.value, err)
+			} else {
+				value = formattedValue
+			}
+		}
+
+		const indentLevel = 3
+		executionSummaryStrings = append(executionSummaryStrings,
+			fmt.Sprintf("%s%s: %s\n", strings.Repeat(" ", indentLevel), field.key, value))
+	}
+
+	if len(executionSummaryStrings) == 0 {
+		return ""
+	}
+
+	sort.Strings(executionSummaryStrings)
+
+	var executionSummaryBuf bytes.Buffer
+	fmt.Fprintln(&executionSummaryBuf, "execution_summary:")
+	fmt.Fprint(&executionSummaryBuf, strings.Join(executionSummaryStrings, ""))
+	return executionSummaryBuf.String()
+}

--- a/visualize/stats_format_test.go
+++ b/visualize/stats_format_test.go
@@ -1,9 +1,13 @@
 package visualize
 
 import (
+	"bytes"
+	"context"
+	"strings"
 	"testing"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spannerplan"
 	"github.com/apstndb/spannerplan/stats"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -21,10 +25,10 @@ func TestFormatExecutionStatsValue(t *testing.T) {
 		{
 			name: "all fields present",
 			input: stats.ExecutionStatsValue{
-				Total:         "100",
-				Unit:          "rows",
-				Mean:          "10",
-				StdDeviation:  "2",
+				Total:        "100",
+				Unit:         "rows",
+				Mean:         "10",
+				StdDeviation: "2",
 			},
 			want: "100@10±2 rows",
 		},
@@ -93,6 +97,9 @@ func TestExecutionStatsToMap(t *testing.T) {
 						"unit":  structpb.NewStringValue("rows"),
 					},
 				}),
+				"rows_returned": structpb.NewStructValue(&structpb.Struct{
+					Fields: map[string]*structpb.Value{"total": structpb.NewStringValue("7")},
+				}),
 				"execution_summary": structpb.NewStructValue(&structpb.Struct{
 					Fields: map[string]*structpb.Value{"num_executions": structpb.NewStringValue("1")},
 				}),
@@ -105,10 +112,11 @@ func TestExecutionStatsToMap(t *testing.T) {
 		t.Fatalf("extractExecutionStats() error = %v", err)
 	}
 
-	got := executionStatsToMap(es)
+	got := executionStatsToMap(node, es)
 	want := map[string]string{
-		"cpu_time": "10ms",
-		"rows":     "100 rows",
+		"cpu_time":      "10ms",
+		"rows":          "100 rows",
+		"rows_returned": "7",
 	}
 	if diff := cmp.Diff(got, want); diff != "" {
 		t.Errorf("executionStatsToMap() mismatch (-got +want):\n%s", diff)
@@ -116,7 +124,20 @@ func TestExecutionStatsToMap(t *testing.T) {
 }
 
 func TestFormatExecutionSummary(t *testing.T) {
-	got := formatExecutionSummary(stats.ExecutionStatsSummary{
+	node := &sppb.PlanNode{
+		ExecutionStats: &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"execution_summary": structpb.NewStructValue(&structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"num_executions": structpb.NewStringValue("1"),
+						"custom_metric":  structpb.NewStringValue("42"),
+					},
+				}),
+			},
+		},
+	}
+
+	got := formatExecutionSummary(node, stats.ExecutionStatsSummary{
 		NumExecutions:           "1",
 		CheckpointTime:          "0.28 msecs",
 		ExecutionStartTimestamp: "1678881600.123456",
@@ -125,6 +146,7 @@ func TestFormatExecutionSummary(t *testing.T) {
 	})
 	want := "execution_summary:\n" +
 		"   checkpoint_time: 0.28 msecs\n" +
+		"   custom_metric: 42\n" +
 		"   execution_end_timestamp: 2023-03-15T12:00:00.654321Z\n" +
 		"   execution_start_timestamp: 2023-03-15T12:00:00.123456Z\n" +
 		"   num_checkpoints: 19\n" +
@@ -215,32 +237,110 @@ func TestTreeNodeGetExecutionSummary(t *testing.T) {
 	}
 }
 
-func TestGetNodeContent_optionGating(t *testing.T) {
-	planNode := &sppb.PlanNode{
+func TestBuildScalarLinkRowIndex_skipsWhenFlagsDisabled(t *testing.T) {
+	qp, err := spannerplan.New([]*sppb.PlanNode{{
 		Index:       0,
-		DisplayName: "Gated Node",
-		Metadata: &structpb.Struct{
-			Fields: map[string]*structpb.Value{
-				"meta_key": structpb.NewStringValue("meta_val"),
-			},
-		},
-		ExecutionStats: &structpb.Struct{
-			Fields: map[string]*structpb.Value{
-				"latency": structpb.NewStructValue(&structpb.Struct{
-					Fields: map[string]*structpb.Value{"total": structpb.NewStringValue("1ms")},
-				}),
-				"execution_summary": structpb.NewStructValue(&structpb.Struct{
-					Fields: map[string]*structpb.Value{"num_executions": structpb.NewStringValue("1")},
-				}),
-			},
+		DisplayName: "Root",
+		Kind:        sppb.PlanNode_RELATIONAL,
+	}})
+	if err != nil {
+		t.Fatalf("spannerplan.New() error = %v", err)
+	}
+
+	rowsByID, err := buildScalarLinkRowIndex(qp, option.Options{})
+	if err != nil {
+		t.Fatalf("buildScalarLinkRowIndex() error = %v", err)
+	}
+	if rowsByID != nil {
+		t.Fatalf("buildScalarLinkRowIndex() = %#v, want nil", rowsByID)
+	}
+}
+
+func TestRenderImage_skipsPlanRowsWhenScalarFlagsDisabled(t *testing.T) {
+	statsToRender := &sppb.ResultSetStats{
+		QueryPlan: &sppb.QueryPlan{
+			PlanNodes: []*sppb.PlanNode{{
+				Index:       0,
+				DisplayName: "Root",
+				Kind:        sppb.PlanNode_RELATIONAL,
+				ExecutionStats: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"broken": structpb.NewStringValue("not-a-stat-struct"),
+					},
+				},
+			}},
 		},
 	}
-	node := &treeNode{planNode: planNode}
+
+	var buf bytes.Buffer
+	err := RenderImage(context.Background(), nil, statsToRender, &buf, option.Options{TypeFlag: "mermaid"})
+	if err != nil {
+		t.Fatalf("RenderImage() error = %v", err)
+	}
+	if !strings.Contains(buf.String(), "Root") {
+		t.Fatalf("RenderImage() output = %q, want root label", buf.String())
+	}
+}
+
+func TestGetNodeContent_optionGating(t *testing.T) {
+	nodes := []*sppb.PlanNode{
+		{
+			Index:       0,
+			DisplayName: "Serialize Result",
+			Kind:        sppb.PlanNode_RELATIONAL,
+			Metadata: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"meta_key": structpb.NewStringValue("meta_val"),
+				},
+			},
+			ChildLinks: []*sppb.PlanNode_ChildLink{
+				{ChildIndex: 1, Type: ""},
+				{ChildIndex: 2, Type: "SCALAR", Variable: "var1"},
+			},
+			ExecutionStats: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"latency": structpb.NewStructValue(&structpb.Struct{
+						Fields: map[string]*structpb.Value{"total": structpb.NewStringValue("1ms")},
+					}),
+					"execution_summary": structpb.NewStructValue(&structpb.Struct{
+						Fields: map[string]*structpb.Value{"num_executions": structpb.NewStringValue("1")},
+					}),
+				},
+			},
+		},
+		{Index: 1, Kind: sppb.PlanNode_SCALAR, ShortRepresentation: &sppb.PlanNode_ShortRepresentation{Description: "col_a"}},
+		{Index: 2, Kind: sppb.PlanNode_SCALAR, ShortRepresentation: &sppb.PlanNode_ShortRepresentation{Description: "assigned"}},
+	}
+	rowType := &sppb.StructType{
+		Fields: []*sppb.StructType_Field{{Name: "col_a"}},
+	}
+
+	qp, err := spannerplan.New(nodes)
+	if err != nil {
+		t.Fatalf("spannerplan.New() error = %v", err)
+	}
+	rowsByID, err := buildPlanRowIndex(qp)
+	if err != nil {
+		t.Fatalf("buildPlanRowIndex() error = %v", err)
+	}
+	node, err := buildNode(qp.GetNodeByIndex(0), rowsByID)
+	if err != nil {
+		t.Fatalf("buildNode() error = %v", err)
+	}
 
 	t.Run("all disabled", func(t *testing.T) {
-		content := node.getNodeContent(nil, option.Options{}, nil)
+		content := node.getNodeContent(nil, option.Options{}, rowType)
 		if len(content.Metadata) != 0 {
 			t.Errorf("Metadata = %v, want empty", content.Metadata)
+		}
+		if len(content.SerializeResult) != 0 {
+			t.Errorf("SerializeResult = %v, want empty", content.SerializeResult)
+		}
+		if len(content.NonVarScalarLinks) != 0 {
+			t.Errorf("NonVarScalarLinks = %v, want empty", content.NonVarScalarLinks)
+		}
+		if len(content.VarScalarLinks) != 0 {
+			t.Errorf("VarScalarLinks = %v, want empty", content.VarScalarLinks)
 		}
 		if len(content.Stats) != 0 {
 			t.Errorf("Stats = %v, want empty", content.Stats)
@@ -252,12 +352,21 @@ func TestGetNodeContent_optionGating(t *testing.T) {
 
 	t.Run("all enabled", func(t *testing.T) {
 		content := node.getNodeContent(nil, option.Options{
-			Metadata:         true,
-			ExecutionStats:   true,
-			ExecutionSummary: true,
-		}, nil)
+			Metadata:          true,
+			SerializeResult:   true,
+			NonVariableScalar: true,
+			VariableScalar:    true,
+			ExecutionStats:    true,
+			ExecutionSummary:  true,
+		}, rowType)
 		if len(content.Metadata) == 0 {
 			t.Error("Metadata should not be empty when enabled")
+		}
+		if len(content.SerializeResult) == 0 {
+			t.Error("SerializeResult should not be empty when enabled")
+		}
+		if len(content.VarScalarLinks) == 0 {
+			t.Error("VarScalarLinks should not be empty when enabled")
 		}
 		if len(content.Stats) == 0 {
 			t.Error("Stats should not be empty when enabled")

--- a/visualize/stats_format_test.go
+++ b/visualize/stats_format_test.go
@@ -1,0 +1,269 @@
+package visualize
+
+import (
+	"testing"
+
+	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spannerplan/stats"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/apstndb/spannerplanviz/option"
+)
+
+func TestFormatExecutionStatsValue(t *testing.T) {
+	tests := []struct {
+		name  string
+		input stats.ExecutionStatsValue
+		want  string
+	}{
+		{
+			name: "all fields present",
+			input: stats.ExecutionStatsValue{
+				Total:         "100",
+				Unit:          "rows",
+				Mean:          "10",
+				StdDeviation:  "2",
+			},
+			want: "100@10±2 rows",
+		},
+		{
+			name: "no std_deviation",
+			input: stats.ExecutionStatsValue{
+				Total: "50",
+				Unit:  "bytes",
+				Mean:  "5",
+			},
+			want: "50@5 bytes",
+		},
+		{
+			name: "no mean or std_deviation",
+			input: stats.ExecutionStatsValue{
+				Total: "200",
+				Unit:  "ms",
+			},
+			want: "200 ms",
+		},
+		{
+			name:  "empty value",
+			input: stats.ExecutionStatsValue{},
+			want:  "",
+		},
+		{
+			name: "missing total",
+			input: stats.ExecutionStatsValue{
+				Unit:         "rows",
+				Mean:         "10",
+				StdDeviation: "2",
+			},
+			want: "@10±2 rows",
+		},
+		{
+			name: "missing unit",
+			input: stats.ExecutionStatsValue{
+				Total:        "100",
+				Mean:         "10",
+				StdDeviation: "2",
+			},
+			want: "100@10±2",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := formatExecutionStatsValue(tt.input)
+			if diff := cmp.Diff(got, tt.want); diff != "" {
+				t.Errorf("formatExecutionStatsValue() mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestExecutionStatsToMap(t *testing.T) {
+	node := &sppb.PlanNode{
+		ExecutionStats: &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"cpu_time": structpb.NewStructValue(&structpb.Struct{
+					Fields: map[string]*structpb.Value{"total": structpb.NewStringValue("10ms")},
+				}),
+				"rows": structpb.NewStructValue(&structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"total": structpb.NewStringValue("100"),
+						"unit":  structpb.NewStringValue("rows"),
+					},
+				}),
+				"execution_summary": structpb.NewStructValue(&structpb.Struct{
+					Fields: map[string]*structpb.Value{"num_executions": structpb.NewStringValue("1")},
+				}),
+			},
+		},
+	}
+
+	es, err := extractExecutionStats(node)
+	if err != nil {
+		t.Fatalf("extractExecutionStats() error = %v", err)
+	}
+
+	got := executionStatsToMap(es)
+	want := map[string]string{
+		"cpu_time": "10ms",
+		"rows":     "100 rows",
+	}
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("executionStatsToMap() mismatch (-got +want):\n%s", diff)
+	}
+}
+
+func TestFormatExecutionSummary(t *testing.T) {
+	got := formatExecutionSummary(stats.ExecutionStatsSummary{
+		NumExecutions:           "1",
+		CheckpointTime:          "0.28 msecs",
+		ExecutionStartTimestamp: "1678881600.123456",
+		ExecutionEndTimestamp:   "1678881600.654321",
+		NumCheckPoints:          "19",
+	})
+	want := "execution_summary:\n" +
+		"   checkpoint_time: 0.28 msecs\n" +
+		"   execution_end_timestamp: 2023-03-15T12:00:00.654321Z\n" +
+		"   execution_start_timestamp: 2023-03-15T12:00:00.123456Z\n" +
+		"   num_checkpoints: 19\n" +
+		"   num_executions: 1\n"
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("formatExecutionSummary() mismatch (-got +want):\n%s", diff)
+	}
+}
+
+func TestTreeNodeGetStats(t *testing.T) {
+	tests := []struct {
+		name     string
+		planNode *sppb.PlanNode
+		param    option.Options
+		want     map[string]string
+	}{
+		{
+			name: "Node with stats",
+			planNode: &sppb.PlanNode{
+				ExecutionStats: &structpb.Struct{
+					Fields: map[string]*structpb.Value{
+						"cpu_time": structpb.NewStructValue(&structpb.Struct{
+							Fields: map[string]*structpb.Value{"total": structpb.NewStringValue("10ms")},
+						}),
+						"rows": structpb.NewStructValue(&structpb.Struct{
+							Fields: map[string]*structpb.Value{"total": structpb.NewStringValue("100")},
+						}),
+						"execution_summary": structpb.NewStructValue(&structpb.Struct{
+							Fields: map[string]*structpb.Value{"num_executions": structpb.NewStringValue("1")},
+						}),
+					},
+				},
+			},
+			param: option.Options{ExecutionStats: true},
+			want: map[string]string{
+				"cpu_time": "10ms",
+				"rows":     "100",
+			},
+		},
+		{
+			name:     "Node with no stats",
+			planNode: &sppb.PlanNode{},
+			param:    option.Options{},
+			want:     nil,
+		},
+		{
+			name:     "Nil plan node",
+			planNode: nil,
+			param:    option.Options{},
+			want:     nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			node := &treeNode{planNode: tt.planNode}
+			got := node.GetStats(tt.param)
+			if diff := cmp.Diff(got, tt.want, cmpopts.EquateEmpty()); diff != "" {
+				t.Errorf("GetStats() mismatch (-got +want):\n%s", diff)
+			}
+		})
+	}
+}
+
+func TestTreeNodeGetExecutionSummary(t *testing.T) {
+	node := &treeNode{
+		planNode: &sppb.PlanNode{
+			ExecutionStats: &structpb.Struct{
+				Fields: map[string]*structpb.Value{
+					"execution_summary": structpb.NewStructValue(&structpb.Struct{
+						Fields: map[string]*structpb.Value{
+							"num_executions": structpb.NewStringValue("10"),
+						},
+					}),
+				},
+			},
+		},
+	}
+
+	got := node.GetExecutionSummary(option.Options{ExecutionSummary: true})
+	want := "execution_summary:\n   num_executions: 10\n"
+	if diff := cmp.Diff(got, want); diff != "" {
+		t.Errorf("GetExecutionSummary() mismatch (-got +want):\n%s", diff)
+	}
+
+	if gotDisabled := node.GetExecutionSummary(option.Options{}); gotDisabled != "" {
+		t.Errorf("GetExecutionSummary() with disabled flag = %q, want empty", gotDisabled)
+	}
+}
+
+func TestGetNodeContent_optionGating(t *testing.T) {
+	planNode := &sppb.PlanNode{
+		Index:       0,
+		DisplayName: "Gated Node",
+		Metadata: &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"meta_key": structpb.NewStringValue("meta_val"),
+			},
+		},
+		ExecutionStats: &structpb.Struct{
+			Fields: map[string]*structpb.Value{
+				"latency": structpb.NewStructValue(&structpb.Struct{
+					Fields: map[string]*structpb.Value{"total": structpb.NewStringValue("1ms")},
+				}),
+				"execution_summary": structpb.NewStructValue(&structpb.Struct{
+					Fields: map[string]*structpb.Value{"num_executions": structpb.NewStringValue("1")},
+				}),
+			},
+		},
+	}
+	node := &treeNode{planNode: planNode}
+
+	t.Run("all disabled", func(t *testing.T) {
+		content := node.getNodeContent(nil, option.Options{}, nil)
+		if len(content.Metadata) != 0 {
+			t.Errorf("Metadata = %v, want empty", content.Metadata)
+		}
+		if len(content.Stats) != 0 {
+			t.Errorf("Stats = %v, want empty", content.Stats)
+		}
+		if content.ExecutionSummary != "" {
+			t.Errorf("ExecutionSummary = %q, want empty", content.ExecutionSummary)
+		}
+	})
+
+	t.Run("all enabled", func(t *testing.T) {
+		content := node.getNodeContent(nil, option.Options{
+			Metadata:         true,
+			ExecutionStats:   true,
+			ExecutionSummary: true,
+		}, nil)
+		if len(content.Metadata) == 0 {
+			t.Error("Metadata should not be empty when enabled")
+		}
+		if len(content.Stats) == 0 {
+			t.Error("Stats should not be empty when enabled")
+		}
+		if content.ExecutionSummary == "" {
+			t.Error("ExecutionSummary should not be empty when enabled")
+		}
+	})
+}

--- a/visualize/visualize.go
+++ b/visualize/visualize.go
@@ -17,6 +17,8 @@ import (
 )
 
 func RenderImage(ctx context.Context, rowType *sppb.StructType, queryStats *sppb.ResultSetStats, writer io.Writer, param option.Options) error {
+	param.ApplyFullOption()
+
 	if queryStats == nil || queryStats.GetQueryPlan() == nil {
 		// This handles cases where the input stats or the plan itself is fundamentally missing.
 		return fmt.Errorf("cannot render image: queryStats or queryPlan is nil")
@@ -30,7 +32,12 @@ func RenderImage(ctx context.Context, rowType *sppb.StructType, queryStats *sppb
 		return fmt.Errorf("failed to create QueryPlan: %w", err)
 	}
 
-	rootNode, err := buildTree(qp, qp.GetNodeByIndex(0), rowType, param)
+	rowsByID, err := buildPlanRowIndex(qp)
+	if err != nil {
+		return fmt.Errorf("failed to process plan rows: %w", err)
+	}
+
+	rootNode, err := buildTree(qp, qp.GetNodeByIndex(0), rowType, param, rowsByID)
 	if err != nil {
 		return fmt.Errorf("failed to build tree: %w", err)
 	}

--- a/visualize/visualize.go
+++ b/visualize/visualize.go
@@ -32,7 +32,7 @@ func RenderImage(ctx context.Context, rowType *sppb.StructType, queryStats *sppb
 		return fmt.Errorf("failed to create QueryPlan: %w", err)
 	}
 
-	rowsByID, err := buildPlanRowIndex(qp)
+	rowsByID, err := buildScalarLinkRowIndex(qp, param)
 	if err != nil {
 		return fmt.Errorf("failed to process plan rows: %w", err)
 	}

--- a/visualize/visualize_test.go
+++ b/visualize/visualize_test.go
@@ -158,9 +158,18 @@ func TestRenderImage_WithQueryStats(t *testing.T) {
 }
 
 func TestRenderMermaid(t *testing.T) {
-	node2Stats, _ := structpb.NewStruct(map[string]interface{}{"rows": "10", "latency": "1ms"})
-	node1Stats, _ := structpb.NewStruct(map[string]interface{}{"rows": "20", "latency": "2ms"})
-	node0Stats, _ := structpb.NewStruct(map[string]interface{}{"rows": "20", "latency": "3ms"})
+	node2Stats, _ := structpb.NewStruct(map[string]interface{}{
+		"rows":    map[string]interface{}{"total": "10", "unit": "rows"},
+		"latency": map[string]interface{}{"total": "1ms"},
+	})
+	node1Stats, _ := structpb.NewStruct(map[string]interface{}{
+		"rows":    map[string]interface{}{"total": "20", "unit": "rows"},
+		"latency": map[string]interface{}{"total": "2ms"},
+	})
+	node0Stats, _ := structpb.NewStruct(map[string]interface{}{
+		"rows":    map[string]interface{}{"total": "20", "unit": "rows"},
+		"latency": map[string]interface{}{"total": "3ms"},
+	})
 
 	stats := &sppb.ResultSetStats{
 		QueryPlan: &sppb.QueryPlan{
@@ -202,25 +211,17 @@ func TestRenderMermaid(t *testing.T) {
 	var rowType *sppb.StructType = nil
 
 	param := option.Options{
-		TypeFlag:          "mermaid",
-		Full:              true,
-		NonVariableScalar: true,
-		VariableScalar:    true,
-		Metadata:          true,
-		ExecutionStats:    true,
-		ExecutionSummary:  true,
-		ShowQuery:         true,
-		ShowQueryStats:    false,
+		TypeFlag:  "mermaid",
+		Full:      true,
+		ShowQuery: true,
 	}
+	param = applyTestOptions(param)
 
 	qp, err := spannerplan.New(stats.GetQueryPlan().GetPlanNodes())
 	if err != nil {
 		t.Fatalf("Failed to create QueryPlan: %v", err)
 	}
-	rootNode, err := buildTree(qp, qp.GetNodeByIndex(0), rowType, param)
-	if err != nil {
-		t.Fatalf("Failed to build tree: %v", err)
-	}
+	rootNode := testBuildTree(t, qp, rowType, param)
 
 	t.Logf("Logging HTML output for treeNodes using param: %+v", param)
 	var logHTML func(n *treeNode)
@@ -265,15 +266,15 @@ func TestRenderMermaid(t *testing.T) {
 graph TD
     node0["<b>Union</b>
 <i>latency: 3ms</i>
-<i>rows: 20</i>"]
+<i>rows: 20&nbsp;rows</i>"]
     style node0 text-align:left;
     node1["<b>Scan1</b>
 <i>latency: 2ms</i>
-<i>rows: 20</i>"]
+<i>rows: 20&nbsp;rows</i>"]
     style node1 text-align:left;
     node2["<b>Scan2</b>
 <i>latency: 1ms</i>
-<i>rows: 10</i>"]
+<i>rows: 10&nbsp;rows</i>"]
     style node2 text-align:left;
     node0 -->|Input| node1
     node0 -->|Input| node2
@@ -318,10 +319,7 @@ func TestRenderMermaid_TextContent(t *testing.T) {
 		t.Fatalf("spannerplan.New failed: %v", err)
 	}
 
-	rootTreeNode, err := buildTree(qp, qp.GetNodeByIndex(0), rowTypeForProcessing, param)
-	if err != nil {
-		t.Fatalf("buildTree failed: %v", err)
-	}
+	rootTreeNode := testBuildTree(t, qp, rowTypeForProcessing, param)
 
 	var allNodesTextContent []string
 	var traverseAndFormat func(n *treeNode) // treeNode is visualize.treeNode
@@ -406,17 +404,11 @@ func TestRenderMermaid_Golden(t *testing.T) {
 	}
 
 	// 4. Define option.Options
-	param := option.Options{
-		TypeFlag:          "mermaid",
-		Full:              true,
-		NonVariableScalar: true,
-		VariableScalar:    true,
-		Metadata:          true,
-		ExecutionStats:    true,
-		ExecutionSummary:  true,
-		ShowQuery:         true,
-		ShowQueryStats:    false,
-	}
+	param := applyTestOptions(option.Options{
+		TypeFlag:  "mermaid",
+		Full:      true,
+		ShowQuery: true,
+	})
 
 	// 5. Create a spannerplan.QueryPlan instance
 	qp, err := spannerplan.New(statsToRender.GetQueryPlan().GetPlanNodes())
@@ -425,14 +417,7 @@ func TestRenderMermaid_Golden(t *testing.T) {
 	}
 
 	// 6. Build the treeNode structure
-	rootPhysicalNode := qp.GetNodeByIndex(0)
-	if rootPhysicalNode == nil {
-		t.Fatalf("Root physical plan node is nil")
-	}
-	rootTreeNode, err := buildTree(qp, rootPhysicalNode, rowTypeToRender, param)
-	if err != nil {
-		t.Fatalf("Failed to build tree: %v", err)
-	}
+	rootTreeNode := testBuildTree(t, qp, rowTypeToRender, param)
 
 	// 7. Create a bytes.Buffer to capture the output
 	var buf bytes.Buffer
@@ -496,14 +481,7 @@ func TestMermaidLabel_Golden(t *testing.T) {
 	}
 
 	// 4. Define option.Options
-	param := option.Options{
-		Full:              true,
-		NonVariableScalar: true,
-		VariableScalar:    true,
-		Metadata:          true,
-		ExecutionStats:    true,
-		ExecutionSummary:  true,
-	}
+	param := applyTestOptions(option.Options{Full: true})
 
 	// 5. Create spannerplan.QueryPlan
 	qp, err := spannerplan.New(statsToProcess.GetQueryPlan().GetPlanNodes())
@@ -512,14 +490,7 @@ func TestMermaidLabel_Golden(t *testing.T) {
 	}
 
 	// 6. Build the treeNode structure
-	rootPhysicalNode := qp.GetNodeByIndex(0)
-	if rootPhysicalNode == nil {
-		t.Fatalf("Root physical plan node is nil")
-	}
-	rootTreeNode, err := buildTree(qp, rootPhysicalNode, rowTypeForProcessing, param)
-	if err != nil {
-		t.Fatalf("Failed to build tree: %v", err)
-	}
+	rootTreeNode := testBuildTree(t, qp, rowTypeForProcessing, param)
 
 	// 7. Create a slice to store all Mermaid labels
 	var allLabels []string


### PR DESCRIPTION
## Summary

- Use `spannerplan/stats.Extract` for typed execution stats and summary formatting in diagram labels
- Use `plantree.ProcessPlan` / `ScalarChildLinks` instead of hand-rolled scalar child link walking
- Restore CLI flag gating for metadata, scalar links, serialize result, and execution summary
- Apply `--full` consistently via `RenderImage` and add unit tests for stats/scalar formatting

## Test plan

- [x] `go test ./...`


Made with [Cursor](https://cursor.com)