### PR TITLE
Bump github.com/apstndb/spannerplan to v0.2.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ toolchain go1.24.0
 require (
 	cloud.google.com/go/spanner v1.48.0
 	github.com/MakeNowJust/heredoc/v2 v2.0.1
-	github.com/apstndb/spannerplan v0.1.11
+	github.com/apstndb/spannerplan v0.2.0
 	github.com/goccy/go-graphviz v0.2.10
 	github.com/google/go-cmp v0.5.9
 	github.com/jessevdk/go-flags v1.6.1

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/MakeNowJust/heredoc/v2 v2.0.1 h1:rlCHh70XXXv7toz95ajQWOWQnN4WNLt0TdpZ
 github.com/MakeNowJust/heredoc/v2 v2.0.1/go.mod h1:6/2Abh5s+hc3g9nbWLe9ObDIOhaRrqsyY9MWy+4JdRM=
 github.com/apstndb/go-tabwrap v0.1.3 h1:5lO2M7Zl5NOus4cve0tu58j3txnNRAEd9MAsFitDCQw=
 github.com/apstndb/go-tabwrap v0.1.3/go.mod h1:duMNZZhNjqj/VXR2AXJN1MWko2RyIytSP1NJyhMmUV4=
-github.com/apstndb/spannerplan v0.1.11 h1:chLsajnYPQI2vwirOeBFNQU0sBWOx9Jet4DuM+zhg2c=
-github.com/apstndb/spannerplan v0.1.11/go.mod h1:7Xfm892U2wPhDrT5nf8NMEvEGtk7eGAh15Qa7e316HA=
+github.com/apstndb/spannerplan v0.2.0 h1:mQyyEHaw2PmDPvum5FQC41+25zb75H35KUm4HKuj6jI=
+github.com/apstndb/spannerplan v0.2.0/go.mod h1:7Xfm892U2wPhDrT5nf8NMEvEGtk7eGAh15Qa7e316HA=
 github.com/clipperhouse/displaywidth v0.11.0 h1:lBc6kY44VFw+TDx4I8opi/EtL9m20WSEFgwIwO+UVM8=
 github.com/clipperhouse/displaywidth v0.11.0/go.mod h1:bkrFNkf81G8HyVqmKGxsPufD3JhNl3dSqnGhOoSD/o0=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=


### PR DESCRIPTION
## Summary

Bumps the `github.com/apstndb/spannerplan` dependency from v0.1.11 to v0.2.0.

spannerplan v0.2.0 added scalar-appendix/print-preset APIs and structured validation errors relative to v0.1.11. Plan-tree/NodeTitle rendering is not affected by this release.

## Validation

- `go test ./...` passes with **no golden regeneration** (only `go.mod`/`go.sum` changed). Verified plan-tree/NodeTitle golden output is unchanged.
- `golangci-lint run` clean (0 issues).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g