### PR TITLE
Make the dot package the single source of truth for graph construction

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,14 @@ spannerplanviz --full --type=mermaid --output profile.mermaid < dca_profile.json
 
 The generated source uses HTML labels and a browser-friendly init block (`htmlLabels: true`, `useMaxWidth: false`). See `visualize/testdata/dca_profile.golden.mermaid` for a full example output.
 
+`--type dot` emits pure Graphviz DOT source (unlaid-out, no `pos`/`bb` layout attributes) via the `dot` package. Pipe it into `dot -Tsvg` (or any Graphviz tool) to lay it out:
+
+```
+spannerplanviz --full --type=dot < dca_profile.json | dot -Tsvg -o profile.svg
+```
+
+`--type svg` and `--type png` still produce fully laid-out output; they generate the same DOT source internally and render it with the embedded Graphviz runtime.
+
 ## Library usage
 
 Build a diagram model once, then render with the backend of your choice:
@@ -73,8 +81,8 @@ Renderers:
 - `mermaid.Source(plan)` — Mermaid.js source using `plan.Build`
 - `mermaid.SourceWithOptions(plan, opts)` — override `plan.Build` at render time (including disabling flags)
 - `mermaid.NewRenderer(opts).Render(ctx, w, plan)` — streaming render
-- `graphviz.NewRenderer(opts).Render(ctx, w, plan)` — SVG/PNG/DOT via Graphviz
-- `dot.Source(plan)` / `dot.SourceWithOptions(plan, opts)` — DOT source text without a Graphviz runtime (no `goccy/go-graphviz` dependency); lay it out elsewhere, e.g. with a browser-side Graphviz build
+- `dot.Source(plan)` / `dot.SourceWithOptions(plan, opts)` — DOT source text without a Graphviz runtime (no `goccy/go-graphviz` dependency); lay it out elsewhere, e.g. with a browser-side Graphviz build. This is the single source of truth for graph construction.
+- `graphviz.NewRenderer(opts).Render(ctx, w, plan)` — SVG/PNG via Graphviz; internally generates the `dot` package's source and hands it to the Graphviz runtime, so both paths describe an identical graph
 
 ## Browser embedding
 

--- a/dot/source.go
+++ b/dot/source.go
@@ -1,12 +1,11 @@
 // Package dot generates Graphviz DOT source text for a built plan without
 // depending on a Graphviz runtime.
 //
-// It mirrors the graph semantics of the graphviz package (same nodes, edges,
-// attributes, and traversal order) but only emits DOT source, so callers that
-// lay out the graph elsewhere (for example in a browser-side Graphviz build)
-// do not need to link github.com/goccy/go-graphviz and its WASM/font stack.
-// Parity with the graphviz package is enforced by tests that parse both
-// outputs and compare them structurally.
+// This package is the single source of truth for graph construction: the
+// graphviz package renders svg/png by generating this DOT source and handing it
+// to the Graphviz runtime, and callers that lay out the graph elsewhere (for
+// example in a browser-side Graphviz build) can consume the source directly
+// without linking github.com/goccy/go-graphviz and its WASM/font stack.
 package dot
 
 import (
@@ -65,8 +64,9 @@ func writeDOT(w io.Writer, plan *visualize.Plan, opts Options) error {
 
 	var sb strings.Builder
 	sb.WriteString("digraph {\n")
-	// Keep these graph attributes in sync with graphviz.Renderer
-	// (SetFontName/SetRankDir/SetStart in the graphviz package).
+	// These graph attributes (fontname, rankdir, start) are the sole source of
+	// truth: the graphviz package embeds this DOT source and does not re-apply
+	// them on the parsed graph.
 	sb.WriteString("\tgraph [fontname=" + quote(`Times New Roman:style=Bold`) + ", rankdir=" + quote("BT") + ", start=" + quote("regular") + "];\n")
 
 	if err := writeTree(&sb, plan.Root, plan); err != nil {

--- a/dot/source_test.go
+++ b/dot/source_test.go
@@ -3,21 +3,17 @@ package dot_test
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"os"
 	"path/filepath"
-	"sort"
 	"strings"
 	"testing"
 
 	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
-	"github.com/goccy/go-graphviz/cgraph"
 	"github.com/google/go-cmp/cmp"
 	"google.golang.org/protobuf/encoding/protojson"
 	"google.golang.org/protobuf/types/known/structpb"
 
 	"github.com/apstndb/spannerplanviz/dot"
-	"github.com/apstndb/spannerplanviz/graphviz"
 	"github.com/apstndb/spannerplanviz/visualize"
 )
 
@@ -141,133 +137,7 @@ func TestSource_goldenDCAProfile(t *testing.T) {
 	}
 }
 
-// TestSource_parityWithGraphvizRenderer is the conformance test for this
-// package: the DOT source must describe the same graph as the graphviz
-// package's DOT output. Both outputs are parsed with Graphviz itself and
-// compared structurally (semantic attributes only — the graphviz package's
-// output additionally contains layout attributes such as pos/bb, which have
-// no counterpart in unlaid-out source).
-func TestSource_parityWithGraphvizRenderer(t *testing.T) {
-	for _, tt := range []struct {
-		fixture string
-		opts    dot.Options
-	}{
-		{"dca_profile.json", dot.Options{}},
-		{"dca_profile.json", dot.Options{ShowQuery: true, ShowQueryStats: true}},
-		{"various_characters_profile.json", dot.Options{}},
-		{"various_characters_profile.json", dot.Options{ShowQuery: true, ShowQueryStats: true}},
-	} {
-		name := fmt.Sprintf("%s/query=%v/stats=%v", tt.fixture, tt.opts.ShowQuery, tt.opts.ShowQueryStats)
-		t.Run(name, func(t *testing.T) {
-			plan := buildPlanFromFixture(t, tt.fixture)
-
-			source, err := dot.SourceWithOptions(plan, tt.opts)
-			if err != nil {
-				t.Fatalf("SourceWithOptions() error = %v", err)
-			}
-
-			var buf bytes.Buffer
-			renderer := graphviz.NewRenderer(graphviz.Options{
-				Format:         graphviz.DOT,
-				ShowQuery:      tt.opts.ShowQuery,
-				ShowQueryStats: tt.opts.ShowQueryStats,
-			})
-			if err := renderer.Render(context.Background(), &buf, plan); err != nil {
-				t.Fatalf("graphviz Render() error = %v", err)
-			}
-
-			gotGraph := parseGraph(t, []byte(source))
-			wantGraph := parseGraph(t, buf.Bytes())
-
-			if diff := cmp.Diff(wantGraph, gotGraph); diff != "" {
-				t.Errorf("graph structure mismatch (-graphviz +dot):\n%s", diff)
-			}
-		})
-	}
-}
-
-// graphRepr is a renderer-independent description of the semantic content of
-// a parsed DOT graph.
-type graphRepr struct {
-	GraphAttrs map[string]string
-	Nodes      map[string]map[string]string
-	Edges      []map[string]string
-}
-
-var (
-	graphAttrKeys = []string{"fontname", "rankdir", "start"}
-	nodeAttrKeys  = []string{"label", "shape", "style", "tooltip"}
-	edgeAttrKeys  = []string{"label", "style"}
-)
-
-func parseGraph(t *testing.T, dotBytes []byte) graphRepr {
-	t.Helper()
-
-	g, err := cgraph.ParseBytes(dotBytes)
-	if err != nil {
-		t.Fatalf("ParseBytes() error = %v", err)
-	}
-	defer func() {
-		if err := g.Close(); err != nil {
-			t.Errorf("close parsed graph: %v", err)
-		}
-	}()
-
-	repr := graphRepr{
-		GraphAttrs: map[string]string{},
-		Nodes:      map[string]map[string]string{},
-	}
-	for _, key := range graphAttrKeys {
-		repr.GraphAttrs[key] = g.GetStr(key)
-	}
-
-	for n, err := g.FirstNode(); n != nil; n, err = g.NextNode(n) {
-		if err != nil {
-			t.Fatalf("iterate nodes: %v", err)
-		}
-
-		name, err := n.Name()
-		if err != nil {
-			t.Fatalf("node name: %v", err)
-		}
-
-		attrs := map[string]string{}
-		for _, key := range nodeAttrKeys {
-			attrs[key] = n.GetStr(key)
-		}
-		repr.Nodes[name] = attrs
-
-		for e, err := g.FirstOut(n); e != nil; e, err = g.NextOut(e) {
-			if err != nil {
-				t.Fatalf("iterate out-edges of %s: %v", name, err)
-			}
-
-			head, err := e.Head()
-			if err != nil {
-				t.Fatalf("edge head: %v", err)
-			}
-			headName, err := head.Name()
-			if err != nil {
-				t.Fatalf("edge head name: %v", err)
-			}
-
-			edgeAttrs := map[string]string{"tail": name, "head": headName}
-			for _, key := range edgeAttrKeys {
-				edgeAttrs[key] = e.GetStr(key)
-			}
-			repr.Edges = append(repr.Edges, edgeAttrs)
-		}
-	}
-
-	sort.Slice(repr.Edges, func(i, j int) bool {
-		a, b := repr.Edges[i], repr.Edges[j]
-		if a["tail"] != b["tail"] {
-			return a["tail"] < b["tail"]
-		}
-		if a["head"] != b["head"] {
-			return a["head"] < b["head"]
-		}
-		return a["label"] < b["label"]
-	})
-	return repr
-}
+// The DOT source this package emits is exercised end-to-end by the graphviz
+// package, which now generates it and hands it to the Graphviz runtime for
+// svg/png rendering. graphviz.TestRenderer_specialCharacters covers the
+// escaping/quoting boundary that the former parity test policed here.

--- a/graphviz/render.go
+++ b/graphviz/render.go
@@ -6,10 +6,9 @@ import (
 	"io"
 	"log"
 
-	sppb "cloud.google.com/go/spanner/apiv1/spannerpb"
+	"github.com/apstndb/spannerplanviz/dot"
 	"github.com/apstndb/spannerplanviz/visualize"
 	"github.com/goccy/go-graphviz"
-	"github.com/goccy/go-graphviz/cgraph"
 )
 
 // Render writes a Graphviz diagram for plan to w.
@@ -26,21 +25,32 @@ func (r *Renderer) Render(ctx context.Context, w io.Writer, plan *visualize.Plan
 	return render(ctx, w, r.Options.Format, plan, r.Options)
 }
 
+// render lays out and renders plan by generating DOT source with the dot
+// package (the single source of truth for graph construction) and handing it to
+// the Graphviz runtime. Graph attributes (fontname, rankdir, start) are already
+// embedded in the DOT source, so they are not re-applied on the parsed graph.
 func render(ctx context.Context, w io.Writer, format Format, plan *visualize.Plan, opts Options) error {
+	source, err := dot.SourceWithOptions(plan, dot.Options{
+		ShowQuery:      opts.ShowQuery,
+		ShowQueryStats: opts.ShowQueryStats,
+	})
+	if err != nil {
+		return fmt.Errorf("failed to generate DOT source: %w", err)
+	}
+
 	g, err := graphviz.New(ctx)
 	if err != nil {
 		return err
 	}
-
 	defer func() {
 		if err := g.Close(); err != nil {
 			log.Print(err)
 		}
 	}()
 
-	graph, err := g.Graph()
+	graph, err := graphviz.ParseBytes([]byte(source))
 	if err != nil {
-		return err
+		return fmt.Errorf("failed to parse DOT source: %w", err)
 	}
 	defer func() {
 		if err := graph.Close(); err != nil {
@@ -48,143 +58,5 @@ func render(ctx context.Context, w io.Writer, format Format, plan *visualize.Pla
 		}
 	}()
 
-	graph.SetStart(graphviz.RegularStart)
-	graph.SetFontName("Times New Roman:style=Bold")
-
-	if err := renderGraph(graph, plan, opts); err != nil {
-		return fmt.Errorf("failed to render graph content: %w", err)
-	}
-
 	return g.Render(ctx, graph, graphviz.Format(format), w)
-}
-
-func renderGraph(graph *cgraph.Graph, plan *visualize.Plan, opts Options) error {
-	graph.SetRankDir(cgraph.BTRank)
-	if err := renderTree(graph, plan.Root, plan); err != nil {
-		return err
-	}
-
-	needQueryNode := (opts.ShowQuery || opts.ShowQueryStats) && plan.QueryStats != nil
-	if needQueryNode {
-		if err := renderQueryNodeWithEdge(graph, plan.QueryStats, opts.ShowQueryStats, plan.Root.GetName()); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func renderQueryNodeWithEdge(graph *cgraph.Graph, queryStats *sppb.ResultSetStats, showQueryStats bool, rootName string) error {
-	str := visualize.FormatQueryNode(queryStats.GetQueryStats().GetFields(), showQueryStats)
-
-	n, err := renderQueryNode(graph, str)
-	if err != nil {
-		return err
-	}
-
-	gvRootNode, err := graph.NodeByName(rootName)
-	if err != nil {
-		return err
-	}
-
-	ed, err := graph.CreateEdgeByName("", gvRootNode, n)
-	if err != nil {
-		return err
-	}
-
-	// Explicitly clear the label: once any edge sets one (renderEdge does),
-	// cgraph declares the attribute with goccy's default "\E", which Graphviz
-	// would otherwise expand to a stray "node0->query" text on this edge.
-	ed.SetLabel("")
-	return nil
-}
-
-func renderTree(graph *cgraph.Graph, node *visualize.TreeNode, plan *visualize.Plan) error {
-	if err := renderNode(graph, node, plan); err != nil {
-		return err
-	}
-
-	for _, child := range node.Children {
-		if err := renderTree(graph, child.ChildNode, plan); err != nil {
-			return err
-		}
-		if err := renderEdge(graph, node, child); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-func renderNode(graph *cgraph.Graph, node *visualize.TreeNode, plan *visualize.Plan) error {
-	n, err := graph.CreateNodeByName(node.GetName())
-	if err != nil {
-		return err
-	}
-
-	n.SetShape(cgraph.BoxShape)
-
-	tooltipStr, err := node.GetTooltip()
-	if err != nil {
-		return fmt.Errorf("error getting tooltip for node %s: %w", node.GetName(), err)
-	}
-
-	n.SetTooltip(tooltipStr)
-
-	nodeHTMLStr := node.HTML(plan.Build, plan.RowType)
-	nodeHTML, err := graph.StrdupHTML(nodeHTMLStr)
-	if err != nil {
-		return err
-	}
-
-	n.SetLabel(nodeHTML)
-	return nil
-}
-
-func renderEdge(graph *cgraph.Graph, parent *visualize.TreeNode, edge *visualize.Link) error {
-	gvChildNode, err := graph.NodeByName(edge.ChildNode.GetName())
-	if err != nil {
-		return err
-	}
-
-	gvNode, err := graph.NodeByName(parent.GetName())
-	if err != nil {
-		return err
-	}
-
-	ed, err := graph.CreateEdgeByName("", gvChildNode, gvNode)
-	if err != nil {
-		return err
-	}
-
-	ed.SetStyle(toCgraphEdgeStyle(edge.Style))
-	ed.SetLabel(edge.ChildType)
-	return nil
-}
-
-func renderQueryNode(graph *cgraph.Graph, queryNodeStr string) (*cgraph.Node, error) {
-	s, err := graph.StrdupHTML(queryNodeStr)
-	if err != nil {
-		return nil, err
-	}
-
-	n, err := graph.CreateNodeByName("query")
-	if err != nil {
-		return nil, err
-	}
-
-	n.SetLabel(s)
-	n.SetShape(cgraph.BoxShape)
-	n.SetStyle(cgraph.RoundedNodeStyle)
-
-	return n, nil
-}
-
-func toCgraphEdgeStyle(style visualize.EdgeStyle) cgraph.EdgeStyle {
-	switch style {
-	case visualize.EdgeStyleDashed:
-		return cgraph.DashedEdgeStyle
-	case visualize.EdgeStyleDotted:
-		return cgraph.DottedEdgeStyle
-	default:
-		return cgraph.SolidEdgeStyle
-	}
 }

--- a/graphviz/render_test.go
+++ b/graphviz/render_test.go
@@ -160,6 +160,69 @@ func TestRenderer_rendersSVG(t *testing.T) {
 	}
 }
 
+// TestRenderer_specialCharacters is a regression test for the DOT source the
+// graphviz renderer now consumes (it generates dot.SourceWithOptions and hands
+// it to the Graphviz runtime). It guards the boundary that the old
+// dot.TestSource_parityWithGraphvizRenderer used to police: a plan whose labels
+// and tooltips contain characters requiring DOT quoting/escaping (quotes,
+// backslashes, angle brackets, non-ASCII) must still parse and render, with the
+// expected node labels surviving into the output.
+func TestRenderer_specialCharacters(t *testing.T) {
+	jsonBytes, err := os.ReadFile(testdataPath("various_characters_profile.json"))
+	if err != nil {
+		t.Fatalf("read various_characters_profile.json: %v", err)
+	}
+
+	var resultSet sppb.ResultSet
+	unmarshalOpts := protojson.UnmarshalOptions{DiscardUnknown: true}
+	if err := unmarshalOpts.Unmarshal(jsonBytes, &resultSet); err != nil {
+		t.Fatalf("unmarshal various_characters_profile.json: %v", err)
+	}
+
+	opts := option.Options{
+		TypeFlag:          "svg",
+		Full:              true,
+		NonVariableScalar: true,
+		VariableScalar:    true,
+		Metadata:          true,
+		ExecutionStats:    true,
+		ExecutionSummary:  true,
+		SerializeResult:   true,
+		ShowQuery:         true,
+		ShowQueryStats:    true,
+	}
+
+	plan, err := visualize.BuildPlan(resultSet.GetMetadata().GetRowType(), resultSet.GetStats(), opts.BuildOptions())
+	if err != nil {
+		t.Fatalf("BuildPlan() error = %v", err)
+	}
+
+	var buf bytes.Buffer
+	renderer := graphviz.NewRenderer(graphviz.Options{
+		Format:         graphviz.SVG,
+		ShowQuery:      true,
+		ShowQueryStats: true,
+	})
+	if err := renderer.Render(context.Background(), &buf, plan); err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+
+	got := buf.String()
+	if !strings.Contains(got, "<svg") {
+		t.Fatalf("Render() output is not SVG: %.80q", got)
+	}
+	for _, want := range []string{
+		"Distributed Union",
+		"Distributed Cross Apply",
+		"Compute Struct",
+		"Serialize Result",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("Render() output missing node label %q", want)
+		}
+	}
+}
+
 func TestRenderer_requiresFormat(t *testing.T) {
 	plan, err := visualize.BuildPlan(nil, &sppb.ResultSetStats{
 		QueryPlan: &sppb.QueryPlan{

--- a/main.go
+++ b/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apstndb/spannerplan"
 	"github.com/jessevdk/go-flags"
 
+	"github.com/apstndb/spannerplanviz/dot"
 	"github.com/apstndb/spannerplanviz/graphviz"
 	"github.com/apstndb/spannerplanviz/mermaid"
 	"github.com/apstndb/spannerplanviz/option"
@@ -130,7 +131,16 @@ func render(ctx context.Context, w io.Writer, plan *visualize.Plan, opts option.
 	switch opts.TypeFlag {
 	case "mermaid":
 		return mermaid.NewRenderer(mermaid.Options{BuildOptions: plan.Build}).Render(ctx, w, plan)
-	case "svg", "png", "dot":
+	case "dot":
+		// --type dot emits pure DOT source via the dot package (the single
+		// source of truth for graph construction) rather than routing through
+		// the Graphviz runtime, so it is unlaid-out source with no layout
+		// attributes (pos/bb/etc.).
+		return dot.NewRenderer(dot.Options{
+			ShowQuery:      opts.ShowQuery,
+			ShowQueryStats: opts.ShowQueryStats,
+		}).Render(ctx, w, plan)
+	case "svg", "png":
 		return graphviz.NewRenderer(graphviz.Options{
 			Format:         graphviz.Format(opts.TypeFlag),
 			ShowQuery:      opts.ShowQuery,


### PR DESCRIPTION
## Summary

The graph was being constructed twice: `graphviz/render.go` built a cgraph directly via goccy/go-graphviz APIs (`renderGraph`/`renderNode`/`renderEdge`/`renderQueryNodeWithEdge`), while the `dot` package (`dot/source.go`) emitted equivalent DOT source. A parity test (`TestSource_parityWithGraphvizRenderer`) policed the duplication by parsing both outputs and comparing them structurally.

This PR makes the `dot` package the single source of truth for graph construction.

## Changes

### 1. graphviz svg/png rendering consumes the dot package

`graphviz/render.go` now generates `dot.SourceWithOptions(plan, dot.Options{ShowQuery, ShowQueryStats})`, parses it with `graphviz.ParseBytes` (goccy), and renders via `g.Render(ctx, graph, format, w)`. The direct-construction code paths (`renderGraph`/`renderTree`/`renderNode`/`renderEdge`/`renderQueryNode*`/`toCgraphEdgeStyle`) are deleted. Graph attributes (`fontname`, `rankdir`, `start`) are embedded in the DOT source by the dot package and are **not** re-applied on the parsed graph.

**SVG goldens are BYTE-IDENTICAL.** `visualize/testdata/full.svg` and `full_with_query_stats.svg` are unchanged: `go test ./...` passes without `UPDATE_GOLDEN_FILES`, and `git diff` shows no change to either golden. Element ids and layout match because the DOT emission order equals the old construction order.

### 2. CLI `--type dot` behavior change (release note)

`--type dot` now emits **pure Graphviz DOT source** via the `dot` package instead of routing through the Graphviz runtime. This is a **deliberate output change**: the output is now unlaid-out source with no `pos`/`bb` layout attributes (previously it was `-Tdot` output annotated by the layout engine). Pipe it into `dot -Tsvg` (or any Graphviz tool) to lay it out. `--type svg`/`--type png` are unaffected and still produce fully laid-out output (generated from the same DOT source internally).

No tests pinned `--type dot` output (checked `main_test.go` and `option/options_test.go`; the latter only asserts `Normalize()` behavior for `TypeFlag: "dot"`, which is unchanged).

### 3. Parity test replacement

Now that svg/png consume the dot output, `TestSource_parityWithGraphvizRenderer` is tautological (it would compare the dot source against a graph re-parsed from that same source). It is replaced by:

- the existing dot golden tests (`dca_profile.golden.dot`), which remain the structural pin for the emitted source, and
- a lighter regression test `graphviz.TestRenderer_specialCharacters` that renders svg from `various_characters_profile.json` (labels/tooltips with quotes, backslashes, angle brackets, non-ASCII) and asserts the DOT input parses and expected node labels survive into the output. This guards the quoting/escaping boundary the old parity test policed.

### 4. README

Documents the new `--type dot` pure-source behavior (with a `| dot -Tsvg` example) and clarifies that the `dot` package is the single source of truth, with `graphviz.NewRenderer` internally generating that source.

## Validation

- `go test ./...` passes (SVG goldens byte-identical, verified without `UPDATE_GOLDEN_FILES`).
- `golangci-lint run` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g
