### PR TITLE
ci: add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+# gomod version updates are deliberately NOT enabled: this module is consumed
+# as a library and keeps its dependency minimums low for MVS friendliness
+# (see ECOSYSTEM.md in apstndb/spannerplan). Dependency and security bumps
+# happen in application modules. Security alerts remain enabled repo-side.
+# cooldown is a Dependabot version-update option. It does not delay security updates.
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    cooldown:
+      default-days: 3
+    groups:
+      github-actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
This repo is a library, so this dependabot config only enables github-actions
version updates (daily schedule, 3-day cooldown, grouped into a single PR).

gomod version updates are deliberately excluded to preserve low dependency
minimums for MVS (Minimal Version Selection) friendliness — see the policy
note in ECOSYSTEM.md in apstndb/spannerplan. Dependency and security bumps
for Go modules happen downstream in application modules instead.

Security alerts remain enabled repo-side regardless of this config (this
config only controls scheduled version-update PRs, not security alerts).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g