### PR TITLE
refactor: backend-neutral graph IR (internal/graphmodel)

### DIFF
--- a/dot/source.go
+++ b/dot/source.go
@@ -14,6 +14,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/apstndb/spannerplanviz/internal/graphmodel"
 	"github.com/apstndb/spannerplanviz/visualize"
 )
 
@@ -62,6 +63,14 @@ func writeDOT(w io.Writer, plan *visualize.Plan, opts Options) error {
 		return fmt.Errorf("cannot render dot: plan is nil")
 	}
 
+	graph, err := visualize.BuildGraph(plan, visualize.GraphOptions{
+		ShowQuery:      opts.ShowQuery,
+		ShowQueryStats: opts.ShowQueryStats,
+	})
+	if err != nil {
+		return err
+	}
+
 	var sb strings.Builder
 	sb.WriteString("digraph {\n")
 	// These graph attributes (fontname, rankdir, start) are the sole source of
@@ -69,64 +78,52 @@ func writeDOT(w io.Writer, plan *visualize.Plan, opts Options) error {
 	// them on the parsed graph.
 	sb.WriteString("\tgraph [fontname=" + quote(`Times New Roman:style=Bold`) + ", rankdir=" + quote("BT") + ", start=" + quote("regular") + "];\n")
 
-	if err := writeTree(&sb, plan.Root, plan); err != nil {
-		return err
-	}
+	writeTree(&sb, graph.Root)
 
-	if (opts.ShowQuery || opts.ShowQueryStats) && plan.QueryStats != nil {
-		queryHTML := visualize.FormatQueryNode(plan.QueryStats.GetQueryStats().GetFields(), opts.ShowQueryStats)
+	if graph.Query != nil {
+		queryHTML := visualize.RenderQueryNodeHTML(graph.Query)
 		sb.WriteString("\t" + quote("query") + " [label=" + htmlString(queryHTML) + ", shape=" + quote("box") + ", style=" + quote("rounded") + "];\n")
-		sb.WriteString("\t" + quote(plan.Root.GetName()) + " -> " + quote("query") + ";\n")
+		sb.WriteString("\t" + quote(graph.Root.ID) + " -> " + quote("query") + ";\n")
 	}
 
 	sb.WriteString("}\n")
-	_, err := io.WriteString(w, sb.String())
+	_, err = io.WriteString(w, sb.String())
 	return err
 }
 
-// writeTree emits node and edge statements in the same pre-order traversal as
-// the graphviz package: a node, then each child subtree followed by the edge
-// from that child to the node.
-func writeTree(sb *strings.Builder, node *visualize.TreeNode, plan *visualize.Plan) error {
-	if err := writeNode(sb, node, plan); err != nil {
-		return err
-	}
+// writeTree emits node and edge statements in a pre-order traversal: a node,
+// then each child subtree followed by the edge from that child to the node.
+// The traversal is intentionally undeduplicated so a shared node's subtree is
+// emitted once per incoming edge, matching the historical graphviz output.
+func writeTree(sb *strings.Builder, node *graphmodel.Node) {
+	writeNode(sb, node)
 
 	for _, child := range node.Children {
-		if err := writeTree(sb, child.ChildNode, plan); err != nil {
-			return err
-		}
+		writeTree(sb, child.To)
 		writeEdge(sb, node, child)
 	}
-	return nil
 }
 
-func writeNode(sb *strings.Builder, node *visualize.TreeNode, plan *visualize.Plan) error {
-	tooltip, err := node.GetTooltip()
-	if err != nil {
-		return fmt.Errorf("error getting tooltip for node %s: %w", node.GetName(), err)
-	}
-
-	sb.WriteString("\t" + quote(node.GetName()) +
-		" [label=" + htmlString(node.HTML(plan.Build, plan.RowType)) +
+func writeNode(sb *strings.Builder, node *graphmodel.Node) {
+	sb.WriteString("\t" + quote(node.ID) +
+		" [label=" + htmlString(visualize.RenderGraphvizNodeHTML(node.Label, node.ID)) +
 		", shape=" + quote("box") +
-		", tooltip=" + quote(tooltip) + "];\n")
-	return nil
+		", tooltip=" + quote(node.Tooltip) + "];\n")
 }
 
-func writeEdge(sb *strings.Builder, parent *visualize.TreeNode, edge *visualize.Link) {
+func writeEdge(sb *strings.Builder, parent *graphmodel.Node, edge graphmodel.Edge) {
 	// Edges point from child to parent; combined with rankdir=BT this places
 	// children below their parent, matching the graphviz package.
-	sb.WriteString("\t" + quote(edge.ChildNode.GetName()) + " -> " + quote(parent.GetName()) +
-		" [label=" + quote(edge.ChildType) +
+	sb.WriteString("\t" + quote(edge.To.ID) + " -> " + quote(parent.ID) +
+		" [label=" + quote(edge.Label) +
 		", style=" + quote(toEdgeStyle(edge.Style)) + "];\n")
 }
 
-func toEdgeStyle(style visualize.EdgeStyle) string {
+func toEdgeStyle(style graphmodel.EdgeStyle) string {
 	switch style {
-	case visualize.EdgeStyleDashed:
+	case graphmodel.EdgeStyleDashed:
 		return "dashed"
-	case visualize.EdgeStyleDotted:
+	case graphmodel.EdgeStyleDotted:
 		return "dotted"
 	default:
 		return "solid"

--- a/internal/graphmodel/graphmodel.go
+++ b/internal/graphmodel/graphmodel.go
@@ -1,0 +1,87 @@
+// Package graphmodel is the backend-neutral intermediate representation of a
+// rendered query plan graph. It carries the fully resolved graph scope (nodes,
+// edges, labels, tooltips and the optional query text) so that each backend
+// serializer (dot, mermaid, d2, ...) can walk a single shared model instead of
+// traversing the visualize.TreeNode graph and resolving formatting concerns on
+// its own.
+//
+// It is the graph-scope analog of the per-node label IR: the model owns
+// structure and semantics, and the serializers own only traversal order,
+// markup and escaping. The model itself is free of any backend syntax.
+package graphmodel
+
+// KV is a key/value pair, used for metadata pairs, execution-stats pairs and
+// query-stat pairs.
+type KV struct {
+	Key   string
+	Value string
+}
+
+// Item is one line of a Label body: either free text (a content line such as
+// the short representation, a scan-info line or a scalar-link line) or a
+// metadata key/value pair. KV is nil for text items and set for pairs.
+type Item struct {
+	Text string
+	KV   *KV
+}
+
+// Label is a backend-neutral representation of a node's label. The sections
+// carry semantic style: Title is bold, Body is plain, and Stats/Summary are
+// italic. Serializers render the sections in field order to reproduce the
+// per-backend layout.
+//
+// Title holds the node title (already escaped for the dominant backend at build
+// time). The dot HTML path composes Title separately with CENTER alignment; the
+// dot body path deliberately omits it. The mermaid path places Title inline at
+// the top of the label.
+type Label struct {
+	Title   string
+	Body    []Item
+	Stats   []KV
+	Summary []string
+}
+
+// EdgeStyle describes how an edge between plan nodes should be drawn.
+type EdgeStyle int
+
+const (
+	// EdgeStyleSolid is a solid line (the default, local links).
+	EdgeStyleSolid EdgeStyle = iota
+	// EdgeStyleDashed is a dashed line (possible remote calls).
+	EdgeStyleDashed
+	// EdgeStyleDotted is a dotted line.
+	EdgeStyleDotted
+)
+
+// Node is a graph node with its resolved label and tooltip.
+//
+// Nodes can be shared: the same *Node may appear as the target of edges from
+// multiple parents. Serializers that dedup (for example the mermaid path) use
+// ID as the identity key; serializers that emit a full traversal (for example
+// the dot path) walk Children directly.
+type Node struct {
+	ID       string
+	Label    Label
+	Tooltip  string
+	Children []Edge
+}
+
+// Edge is a link from a parent Node to a child Node.
+type Edge struct {
+	Style EdgeStyle
+	Label string
+	To    *Node
+}
+
+// QueryText is the optional query-text node's content. Stats is sorted by key
+// and is empty unless query stats were requested.
+type QueryText struct {
+	Text  string
+	Stats []KV
+}
+
+// Graph is the whole resolved plan graph.
+type Graph struct {
+	Root  *Node
+	Query *QueryText
+}

--- a/mermaid/render.go
+++ b/mermaid/render.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"strings"
 
+	"github.com/apstndb/spannerplanviz/internal/graphmodel"
 	"github.com/apstndb/spannerplanviz/visualize"
 )
 
@@ -68,6 +69,16 @@ func writeMermaid(writer io.Writer, plan *visualize.Plan, build visualize.BuildO
 
 	build.ApplyFull()
 
+	// Labels are built from plan.Build. mermaid can override build options at
+	// render time, so resolve the graph from a shallow copy carrying the
+	// render-time options rather than plan.Build.
+	planForGraph := *plan
+	planForGraph.Build = build
+	graph, err := visualize.BuildGraph(&planForGraph, visualize.GraphOptions{})
+	if err != nil {
+		return err
+	}
+
 	b, err := json.Marshal(mermaidInitConfig())
 	if err != nil {
 		return err
@@ -80,46 +91,45 @@ func writeMermaid(writer io.Writer, plan *visualize.Plan, build visualize.BuildO
 	renderedNodes := make(map[string]bool)
 	var edgesToRender []string
 
-	styleTranslation := map[visualize.EdgeStyle]string{
-		visualize.EdgeStyleSolid:  "-->",
-		visualize.EdgeStyleDashed: "-.->",
-		visualize.EdgeStyleDotted: "-.->",
+	styleTranslation := map[graphmodel.EdgeStyle]string{
+		graphmodel.EdgeStyleSolid:  "-->",
+		graphmodel.EdgeStyleDashed: "-.->",
+		graphmodel.EdgeStyleDotted: "-.->",
 	}
 
-	var walk func(*visualize.TreeNode)
-	walk = func(node *visualize.TreeNode) {
+	var walk func(*graphmodel.Node)
+	walk = func(node *graphmodel.Node) {
 		if node == nil {
 			return
 		}
-		nodeName := node.GetName()
-		if _, visited := renderedNodes[nodeName]; visited {
+		if renderedNodes[node.ID] {
 			return
 		}
-		renderedNodes[nodeName] = true
+		renderedNodes[node.ID] = true
 
-		finalLabel := node.MermaidLabel(build, plan.RowType)
+		finalLabel := visualize.RenderMermaidLabel(node.Label, node.ID)
 
-		fmt.Fprintf(&sb, "    %s[\"%s\"]\n", nodeName, finalLabel)
-		fmt.Fprintf(&sb, "    style %s text-align:left;\n", nodeName)
+		fmt.Fprintf(&sb, "    %s[\"%s\"]\n", node.ID, finalLabel)
+		fmt.Fprintf(&sb, "    style %s text-align:left;\n", node.ID)
 
-		for _, edgeLink := range node.Children {
-			arrow, ok := styleTranslation[edgeLink.Style]
+		for _, edge := range node.Children {
+			arrow, ok := styleTranslation[edge.Style]
 			if !ok {
 				arrow = "-->"
 			}
 
 			var edgeLabelPart string
-			if edgeLink.ChildType != "" {
-				edgeLabelPart = fmt.Sprintf("|%s|", escapeMermaidEdgeLabel(edgeLink.ChildType))
+			if edge.Label != "" {
+				edgeLabelPart = fmt.Sprintf("|%s|", escapeMermaidEdgeLabel(edge.Label))
 			}
-			edgeStr := fmt.Sprintf("    %s %s%s %s\n", nodeName, arrow, edgeLabelPart, edgeLink.ChildNode.GetName())
+			edgeStr := fmt.Sprintf("    %s %s%s %s\n", node.ID, arrow, edgeLabelPart, edge.To.ID)
 			edgesToRender = append(edgesToRender, edgeStr)
 
-			walk(edgeLink.ChildNode)
+			walk(edge.To)
 		}
 	}
 
-	walk(plan.Root)
+	walk(graph.Root)
 
 	for _, edgeStr := range edgesToRender {
 		sb.WriteString(edgeStr)

--- a/visualize/build_tree.go
+++ b/visualize/build_tree.go
@@ -16,6 +16,8 @@ import (
 	"github.com/apstndb/spannerplan"
 	"github.com/apstndb/spannerplan/plantree"
 	"google.golang.org/protobuf/types/known/structpb"
+
+	"github.com/apstndb/spannerplanviz/internal/graphmodel"
 )
 
 // This file contains logics which are purely formatting strings and building tree structures.
@@ -184,37 +186,12 @@ func (n *TreeNode) getNodeContent(param BuildOptions, rowType *sppb.StructType) 
 	return content
 }
 
-// labelKV is a metadata or execution-stats key/value pair in a nodeLabel.
-type labelKV struct {
-	Key   string
-	Value string
-}
-
-// labelItem is one line of a nodeLabel body: either free text (a content line
-// such as the short representation, a scan-info line or a scalar-link line) or
-// a metadata key/value pair. KV is nil for text items and set for pairs.
-type labelItem struct {
-	Text string
-	KV   *labelKV
-}
-
-// nodeLabel is a backend-neutral intermediate representation of a node's label.
-// It is built once from nodeContent by buildNodeLabel and rendered into the
-// Mermaid or Graphviz label syntaxes by the emitters, which own only escaping
-// and markup. The sections carry semantic style: Title is bold, Body is plain,
-// and Stats/Summary are italic. Emitting them in field order reproduces the
-// historical per-backend layout.
-//
-// Title is consumed only by the Mermaid emitter, which escapes it and places it
-// inline at the top of the label. The Graphviz body emitter deliberately omits
-// Title because the Graphviz path composes it separately in HTML (with its own
-// escaping and CENTER alignment relative to the body).
-type nodeLabel struct {
-	Title   string      // node title, rendered bold; empty when absent
-	Body    []labelItem // plain content lines and metadata pairs, in display order
-	Stats   []labelKV   // execution-stats key/value pairs, rendered italic
-	Summary []string    // execution-summary lines, rendered italic
-}
+// The backend-neutral label IR (graphmodel.Label / graphmodel.Item /
+// graphmodel.KV) lives in internal/graphmodel so that every serializer package
+// can consume it. buildNodeLabel builds it from nodeContent, and the emitter
+// functions (renderMermaidLabel, renderGraphvizLabelBody, renderGraphvizNodeHTML)
+// own only escaping and markup. The sections carry semantic style: Title is
+// bold, Body is plain, and Stats/Summary are italic.
 
 // sortedStringKeys returns the keys of m in ascending order.
 func sortedStringKeys(m map[string]string) []string {
@@ -226,17 +203,17 @@ func sortedStringKeys(m map[string]string) []string {
 	return keys
 }
 
-// buildNodeLabel assembles the backend-neutral nodeLabel from the node's raw
-// content. It owns section ordering, key sorting and empty-line filtering so
+// buildNodeLabel assembles the backend-neutral graphmodel.Label from the node's
+// raw content. It owns section ordering, key sorting and empty-line filtering so
 // that the Mermaid and Graphviz emitters share a single source of truth.
-func (n *TreeNode) buildNodeLabel(param BuildOptions, rowType *sppb.StructType) nodeLabel {
+func (n *TreeNode) buildNodeLabel(param BuildOptions, rowType *sppb.StructType) graphmodel.Label {
 	content := n.getNodeContent(param, rowType)
 
-	label := nodeLabel{Title: content.Title}
+	label := graphmodel.Label{Title: content.Title}
 
 	appendText := func(line string) {
 		if line != "" {
-			label.Body = append(label.Body, labelItem{Text: line})
+			label.Body = append(label.Body, graphmodel.Item{Text: line})
 		}
 	}
 
@@ -251,14 +228,14 @@ func (n *TreeNode) buildNodeLabel(param BuildOptions, rowType *sppb.StructType) 
 		appendText(line)
 	}
 	for _, k := range sortedStringKeys(content.Metadata) {
-		label.Body = append(label.Body, labelItem{KV: &labelKV{Key: k, Value: content.Metadata[k]}})
+		label.Body = append(label.Body, graphmodel.Item{KV: &graphmodel.KV{Key: k, Value: content.Metadata[k]}})
 	}
 	for _, line := range content.VarScalarLinks {
 		appendText(line)
 	}
 
 	for _, k := range sortedStringKeys(content.Stats) {
-		label.Stats = append(label.Stats, labelKV{Key: k, Value: content.Stats[k]})
+		label.Stats = append(label.Stats, graphmodel.KV{Key: k, Value: content.Stats[k]})
 	}
 
 	for _, line := range strings.Split(strings.TrimSuffix(content.ExecutionSummary, "\n"), "\n") {
@@ -270,9 +247,18 @@ func (n *TreeNode) buildNodeLabel(param BuildOptions, rowType *sppb.StructType) 
 	return label
 }
 
-// mermaid renders the label as a Mermaid flowchart HTML-ish label. fallback is
-// used verbatim (after escaping) when the label would otherwise be empty.
-func (l nodeLabel) mermaid(fallback string) string {
+// RenderMermaidLabel renders a graphmodel.Label as a Mermaid flowchart HTML-ish
+// label. fallback is used verbatim (after escaping) when the label would
+// otherwise be empty. It is exported so the mermaid serializer can render the
+// graph IR built by BuildGraph.
+func RenderMermaidLabel(l graphmodel.Label, fallback string) string {
+	return renderMermaidLabel(l, fallback)
+}
+
+// renderMermaidLabel renders the label as a Mermaid flowchart HTML-ish label.
+// fallback is used verbatim (after escaping) when the label would otherwise be
+// empty.
+func renderMermaidLabel(l graphmodel.Label, fallback string) string {
 	var labelParts []string
 
 	if l.Title != "" {
@@ -308,9 +294,10 @@ func (l nodeLabel) mermaid(fallback string) string {
 	return labelContent
 }
 
-// graphviz renders the label body and stats as a Graphviz HTML-like label
-// fragment. The node title is not included; the Graphviz path adds it in HTML.
-func (l nodeLabel) graphviz() string {
+// renderGraphvizLabelBody renders the label body and stats as a Graphviz
+// HTML-like label fragment. The node title is not included; the Graphviz path
+// adds it in HTML.
+func renderGraphvizLabelBody(l graphmodel.Label) string {
 	var bodyLines []string
 	for _, item := range l.Body {
 		if item.KV != nil {
@@ -336,7 +323,7 @@ func (l nodeLabel) graphviz() string {
 
 // MermaidLabel generates the label string for this node, suitable for use in Mermaid diagrams.
 func (n *TreeNode) MermaidLabel(param BuildOptions, rowType *sppb.StructType) string {
-	return n.buildNodeLabel(param, rowType).mermaid(n.GetName())
+	return renderMermaidLabel(n.buildNodeLabel(param, rowType), n.GetName())
 }
 
 // GetName generates the node's unique ID for graph rendering.
@@ -436,20 +423,30 @@ func (n *TreeNode) GetExecutionSummary(param BuildOptions) string {
 
 // Metadata formats node content for GraphViz HTML-like labels.
 func (n *TreeNode) Metadata(param BuildOptions, rowType *sppb.StructType) string {
-	return n.buildNodeLabel(param, rowType).graphviz()
+	return renderGraphvizLabelBody(n.buildNodeLabel(param, rowType))
 }
 
 func (n *TreeNode) HTML(param BuildOptions, rowType *sppb.StructType) string {
-	titleHTML := ""
-	if t := n.GetTitle(); t != "" {
-		// n.GetTitle calls spannerplan.NodeTitle which already HTML escapes its content.
-		titleHTML = markupIfNotEmpty("b", t)
-	}
+	return renderGraphvizNodeHTML(n.buildNodeLabel(param, rowType), n.GetName())
+}
 
-	metadataHTML := n.Metadata(param, rowType)
+// RenderGraphvizNodeHTML renders a graphmodel.Label as the full Graphviz
+// HTML-like node label (title composed with the body/stats fragment). fallbackID
+// is emitted (HTML-escaped) when the label is empty. It is exported so the dot
+// serializer can render the graph IR built by BuildGraph.
+func RenderGraphvizNodeHTML(l graphmodel.Label, fallbackID string) string {
+	return renderGraphvizNodeHTML(l, fallbackID)
+}
+
+// renderGraphvizNodeHTML composes the node title (bold, CENTER-aligned) with the
+// Graphviz body/stats fragment. The Title in the label is already HTML-escaped
+// (spannerplan.NodeTitle escapes its content), so it is emitted verbatim.
+func renderGraphvizNodeHTML(l graphmodel.Label, fallbackID string) string {
+	titleHTML := markupIfNotEmpty("b", l.Title)
+	metadataHTML := renderGraphvizLabelBody(l)
 
 	if titleHTML == "" && metadataHTML == "" {
-		return html.EscapeString(n.GetName())
+		return html.EscapeString(fallbackID)
 	}
 	if titleHTML == "" {
 		return metadataHTML
@@ -525,26 +522,60 @@ func prefixIfNotEmpty(prefix, value string) string {
 	return prefix + value
 }
 
-func formatQueryStats(stats map[string]*structpb.Value) string {
-	var result []string
-	for k, v := range stats {
-		result = append(result, fmt.Sprintf("%s: %s", k, v.GetStringValue()))
-	}
-
-	sort.Strings(result)
-	return strings.Join(result, "\n")
-}
-
-func FormatQueryNode(queryStats map[string]*structpb.Value, showQueryStats bool) string {
+// buildQueryText extracts the structured query-text content from a
+// ResultSetStats query_stats map: the query text plus, when showQueryStats is
+// set, the remaining stats as key/value pairs sorted by key. The keys here are
+// distinct and free of separator collisions, so sorting by key reproduces the
+// historical order (which sorted the rendered "key: value" lines).
+func buildQueryText(queryStats map[string]*structpb.Value, showQueryStats bool) *graphmodel.QueryText {
 	m := maps.Clone(queryStats)
 	const queryTextKey = "query_text"
-	text := m[queryTextKey].GetStringValue()
+	q := &graphmodel.QueryText{Text: m[queryTextKey].GetStringValue()}
 	delete(m, queryTextKey)
-	var buf strings.Builder
-	buf.WriteString(markupIfNotEmpty("b", toLeftAlignedText(escapeGraphvizHTMLLabelContent(text)))) // Changed to toLeftAlignedText
+
 	if showQueryStats {
-		statsStr := formatQueryStats(m)
-		buf.WriteString(markupIfNotEmpty("i", toLeftAlignedText(escapeGraphvizHTMLLabelContent(statsStr)))) // Changed to toLeftAlignedText
+		for _, k := range sortedStringKeys(mapStringValues(m)) {
+			q.Stats = append(q.Stats, graphmodel.KV{Key: k, Value: m[k].GetStringValue()})
+		}
+	}
+	return q
+}
+
+// mapStringValues projects a structpb value map onto its string-valued view so
+// buildQueryText can reuse sortedStringKeys for deterministic key ordering.
+func mapStringValues(m map[string]*structpb.Value) map[string]string {
+	out := make(map[string]string, len(m))
+	for k, v := range m {
+		out[k] = v.GetStringValue()
+	}
+	return out
+}
+
+// RenderQueryNodeHTML renders a graphmodel.QueryText as the Graphviz HTML-like
+// query node label: the query text in bold, followed by the italic stat lines
+// when present. It is exported so the dot serializer can render the query node
+// from the graph IR built by BuildGraph.
+func RenderQueryNodeHTML(q *graphmodel.QueryText) string {
+	if q == nil {
+		return ""
+	}
+	var buf strings.Builder
+	buf.WriteString(markupIfNotEmpty("b", toLeftAlignedText(escapeGraphvizHTMLLabelContent(q.Text))))
+	if len(q.Stats) > 0 {
+		lines := make([]string, 0, len(q.Stats))
+		for _, kv := range q.Stats {
+			lines = append(lines, fmt.Sprintf("%s: %s", kv.Key, kv.Value))
+		}
+		statsStr := strings.Join(lines, "\n")
+		buf.WriteString(markupIfNotEmpty("i", toLeftAlignedText(escapeGraphvizHTMLLabelContent(statsStr))))
 	}
 	return buf.String()
+}
+
+// FormatQueryNode renders the Graphviz HTML-like query node label directly from
+// a ResultSetStats query_stats map. It is retained for backward compatibility
+// and now delegates to the structured buildQueryText/RenderQueryNodeHTML path so
+// there is a single source of truth for the query node content.
+func FormatQueryNode(queryStats map[string]*structpb.Value, showQueryStats bool) string {
+	return RenderQueryNodeHTML(buildQueryText(queryStats, showQueryStats))
 }

--- a/visualize/graph.go
+++ b/visualize/graph.go
@@ -1,0 +1,98 @@
+package visualize
+
+import (
+	"fmt"
+
+	"github.com/apstndb/spannerplanviz/internal/graphmodel"
+)
+
+// GraphOptions controls optional content included when building the backend-neutral
+// graph model.
+type GraphOptions struct {
+	// ShowQuery adds a query-text node built from the ResultSetStats query_stats.
+	ShowQuery bool
+	// ShowQueryStats adds the query statistics to the query-text node.
+	ShowQueryStats bool
+}
+
+// BuildGraph resolves a built Plan into the backend-neutral graphmodel.Graph:
+// node labels (via buildNodeLabel using plan.Build), tooltips (canonical YAML),
+// edge styles, and the optional query-text node. Serializers consume the graph
+// instead of walking the TreeNode graph directly.
+//
+// Node identity from the TreeNode graph is preserved: a TreeNode reached from
+// multiple parents maps to a single *graphmodel.Node, so pointer sharing in the
+// source survives into the model. Each serializer keeps its own traversal order
+// (the dot path emits a full pre-order traversal; the mermaid path dedups by
+// node ID), so the resolved model does not move any bytes.
+//
+// Labels are built with plan.Build. Callers that need to override build options
+// at render time (for example mermaid.SourceWithOptions) do so by shallow-copying
+// the Plan and setting Plan.Build before calling BuildGraph.
+func BuildGraph(plan *Plan, opts GraphOptions) (*graphmodel.Graph, error) {
+	if plan == nil || plan.Root == nil {
+		return nil, fmt.Errorf("cannot build graph: plan is nil")
+	}
+
+	nodeMap := make(map[*TreeNode]*graphmodel.Node)
+
+	var buildNode func(tn *TreeNode) (*graphmodel.Node, error)
+	buildNode = func(tn *TreeNode) (*graphmodel.Node, error) {
+		if existing, ok := nodeMap[tn]; ok {
+			return existing, nil
+		}
+
+		tooltip, err := tn.GetTooltip()
+		if err != nil {
+			return nil, fmt.Errorf("error getting tooltip for node %s: %w", tn.GetName(), err)
+		}
+
+		gnode := &graphmodel.Node{
+			ID:      tn.GetName(),
+			Label:   tn.buildNodeLabel(plan.Build, plan.RowType),
+			Tooltip: tooltip,
+		}
+		// Register before recursion so shared children (and any future cycles)
+		// resolve to the same node.
+		nodeMap[tn] = gnode
+
+		for _, link := range tn.Children {
+			child, err := buildNode(link.ChildNode)
+			if err != nil {
+				return nil, err
+			}
+			gnode.Children = append(gnode.Children, graphmodel.Edge{
+				Style: toGraphEdgeStyle(link.Style),
+				Label: link.ChildType,
+				To:    child,
+			})
+		}
+		return gnode, nil
+	}
+
+	root, err := buildNode(plan.Root)
+	if err != nil {
+		return nil, err
+	}
+
+	graph := &graphmodel.Graph{Root: root}
+
+	if (opts.ShowQuery || opts.ShowQueryStats) && plan.QueryStats != nil {
+		graph.Query = buildQueryText(plan.QueryStats.GetQueryStats().GetFields(), opts.ShowQueryStats)
+	}
+
+	return graph, nil
+}
+
+// toGraphEdgeStyle maps a visualize.EdgeStyle onto the backend-neutral
+// graphmodel.EdgeStyle.
+func toGraphEdgeStyle(style EdgeStyle) graphmodel.EdgeStyle {
+	switch style {
+	case EdgeStyleDashed:
+		return graphmodel.EdgeStyleDashed
+	case EdgeStyleDotted:
+		return graphmodel.EdgeStyleDotted
+	default:
+		return graphmodel.EdgeStyleSolid
+	}
+}


### PR DESCRIPTION
## Summary

Introduces `internal/graphmodel`, a backend-neutral intermediate representation of the whole plan graph, and rewires the `dot` and `mermaid` serializers to consume it. This is the graph-scope analog of the per-node label IR from #54: the model owns structure and semantics (nodes, edges, labels, tooltips, the optional query text), and the serializers own only traversal order, markup and escaping.

## What changed

- **`internal/graphmodel`** — new package (`Graph`, `Node`, `Edge`, `Label`, `Item`, `KV`, `QueryText`, `EdgeStyle`). The `#54` label IR is moved here and exported. Backend-syntax-free.
- **`visualize.BuildGraph(plan, GraphOptions{ShowQuery, ShowQueryStats})`** resolves a built `Plan` into a `*graphmodel.Graph`: labels (via `buildNodeLabel`, now producing `graphmodel.Label`), tooltips (canonical YAML, resolved at build time and stored on the node), edge styles, and the optional structured query-text node extracted from `ResultSetStats` `query_stats` (text + stat KVs sorted by key). Node identity is preserved by memoizing on the source `*TreeNode`, so pointer sharing survives into the model.
- **`dot/source.go`** and **`mermaid/render.go`** now walk `*graphmodel.Graph` instead of `TreeNode` directly. Each serializer keeps its own traversal order (dot emits a full undeduplicated pre-order traversal; mermaid dedups by node ID) so no bytes move.
- The label emitters stay in `visualize` and consume `graphmodel.Label`/`QueryText` (`RenderMermaidLabel`, `RenderGraphvizNodeHTML`, `RenderQueryNodeHTML`). Public methods `MermaidLabel`/`Metadata`/`HTML`/`GetTooltip`/`GetName` keep their signatures. `FormatQueryNode` now delegates to the structured path (single source of truth for the query node content).

## Guarantees

Pure refactor with **zero output change**: every pre-existing golden is byte-identical — `dca_profile.golden.mermaid`, `dca_profile.mermaid_labels.golden`, `dca_profile.golden.dot`, `full.svg`, `full_with_query_stats.svg`.

- `go test ./...` (without `UPDATE_GOLDEN_FILES`): pass
- `golangci-lint run`: clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Du9UR1LPdSXk4wAZr4Nf4g